### PR TITLE
Use venv python only, if it's available

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ The name "Forge" is inspired by "Minecraft Forge". This project aims to become t
 - Set up **venv**
     ```bash
     cd sd-webui-forge-classic
-    uv venv venv --python 3.11
+    uv venv venv --python 3.11 --seed
     ```
 - Add the `--uv` flag *(see [Commandline](#classic))*
 

--- a/webui.bat
+++ b/webui.bat
@@ -13,6 +13,8 @@ set ERROR_REPORTING=FALSE
 
 mkdir tmp 2>NUL
 
+uv help python >tmp/stdout.txt 2>tmp/stderr.txt
+if %ERRORLEVEL% == 0 goto :check_pip
 %PYTHON% -c "" >tmp/stdout.txt 2>tmp/stderr.txt
 if %ERRORLEVEL% == 0 goto :check_pip
 echo Couldn't launch python

--- a/webui.bat
+++ b/webui.bat
@@ -13,21 +13,6 @@ set ERROR_REPORTING=FALSE
 
 mkdir tmp 2>NUL
 
-%PYTHON% -c "" >tmp/stdout.txt 2>tmp/stderr.txt
-if %ERRORLEVEL% == 0 goto :check_pip
-echo Couldn't launch python
-goto :show_stdout_stderr
-
-:check_pip
-%PYTHON% -mpip --help >tmp/stdout.txt 2>tmp/stderr.txt
-if %ERRORLEVEL% == 0 goto :start_venv
-if "%PIP_INSTALLER_LOCATION%" == "" goto :show_stdout_stderr
-%PYTHON% "%PIP_INSTALLER_LOCATION%" >tmp/stdout.txt 2>tmp/stderr.txt
-if %ERRORLEVEL% == 0 goto :start_venv
-echo Couldn't install pip
-goto :show_stdout_stderr
-
-:start_venv
 if ["%VENV_DIR%"] == ["-"] goto :skip_venv
 if ["%SKIP_VENV%"] == ["1"] goto :skip_venv
 
@@ -52,6 +37,22 @@ call "%VENV_DIR%\Scripts\activate.bat"
 echo venv %PYTHON%
 
 :skip_venv
+:check_python
+%PYTHON% -c "" >tmp/stdout.txt 2>tmp/stderr.txt
+if %ERRORLEVEL% == 0 goto :check_pip
+echo Couldn't launch python
+goto :show_stdout_stderr
+
+:check_pip
+%PYTHON% -mpip --help >tmp/stdout.txt 2>tmp/stderr.txt
+if %ERRORLEVEL% == 0 goto :launch_or_accelerate
+if "%PIP_INSTALLER_LOCATION%" == "" goto :show_stdout_stderr
+%PYTHON% "%PIP_INSTALLER_LOCATION%" >tmp/stdout.txt 2>tmp/stderr.txt
+if %ERRORLEVEL% == 0 goto :launch_or_accelerate
+echo Couldn't install pip
+goto :show_stdout_stderr
+
+:launch_or_accelerate
 if [%ACCELERATE%] == ["True"] goto :accelerate
 goto :launch
 
@@ -62,14 +63,14 @@ if EXIST %ACCELERATE% goto :accelerate_launch
 
 :launch
 %PYTHON% launch.py %*
-if EXIST tmp/restart goto :skip_venv
+if EXIST tmp/restart goto :launch_or_accelerate
 pause
 exit /b
 
 :accelerate_launch
 echo Accelerating
 %ACCELERATE% launch --num_cpu_threads_per_process=6 launch.py
-if EXIST tmp/restart goto :skip_venv
+if EXIST tmp/restart goto :launch_or_accelerate
 pause
 exit /b
 

--- a/webui.bat
+++ b/webui.bat
@@ -13,6 +13,20 @@ set ERROR_REPORTING=FALSE
 
 mkdir tmp 2>NUL
 
+%PYTHON% -c "" >tmp/stdout.txt 2>tmp/stderr.txt
+if %ERRORLEVEL% == 0 goto :check_pip
+echo Couldn't launch python
+goto :show_stdout_stderr
+
+:check_pip
+uv help pip >tmp/stdout.txt 2>tmp/stderr.txt
+if %ERRORLEVEL% == 0 goto :start_venv
+%PYTHON% -m pip --help >tmp/stdout.txt 2>tmp/stderr.txt
+if %ERRORLEVEL% == 0 goto :start_venv
+echo Couldn't launch pip
+goto :show_stdout_stderr
+
+:start_venv
 if ["%VENV_DIR%"] == ["-"] goto :skip_venv
 if ["%SKIP_VENV%"] == ["1"] goto :skip_venv
 
@@ -37,22 +51,6 @@ call "%VENV_DIR%\Scripts\activate.bat"
 echo venv %PYTHON%
 
 :skip_venv
-:check_python
-%PYTHON% -c "" >tmp/stdout.txt 2>tmp/stderr.txt
-if %ERRORLEVEL% == 0 goto :check_pip
-echo Couldn't launch python
-goto :show_stdout_stderr
-
-:check_pip
-%PYTHON% -mpip --help >tmp/stdout.txt 2>tmp/stderr.txt
-if %ERRORLEVEL% == 0 goto :launch_or_accelerate
-if "%PIP_INSTALLER_LOCATION%" == "" goto :show_stdout_stderr
-%PYTHON% "%PIP_INSTALLER_LOCATION%" >tmp/stdout.txt 2>tmp/stderr.txt
-if %ERRORLEVEL% == 0 goto :launch_or_accelerate
-echo Couldn't install pip
-goto :show_stdout_stderr
-
-:launch_or_accelerate
 if [%ACCELERATE%] == ["True"] goto :accelerate
 goto :launch
 
@@ -63,14 +61,14 @@ if EXIST %ACCELERATE% goto :accelerate_launch
 
 :launch
 %PYTHON% launch.py %*
-if EXIST tmp/restart goto :launch_or_accelerate
+if EXIST tmp/restart goto :skip_venv
 pause
 exit /b
 
 :accelerate_launch
 echo Accelerating
 %ACCELERATE% launch --num_cpu_threads_per_process=6 launch.py
-if EXIST tmp/restart goto :launch_or_accelerate
+if EXIST tmp/restart goto :skip_venv
 pause
 exit /b
 


### PR DESCRIPTION
With `uv`, it's possible there's only uv's venv python and no system python. `webui.bat` checks system python first and errors out if it's not there, but we'll be using venv python most of the time so system python is not even necessary.

This PR delegates python & pip checking to after venv check & activation, so if venv python is available then only that one is used.

Also added --seed flag to installation steps because it was necessary in my case for whatever reason.