### PR TITLE
"added" normaldsine as a preprocessor

### DIFF
--- a/extensions-builtin/forge_preprocessor_normaldsine/annotator/annotator_path.py
+++ b/extensions-builtin/forge_preprocessor_normaldsine/annotator/annotator_path.py
@@ -1,0 +1,19 @@
+from modules_forge.shared import preprocessor_dir
+import os
+
+try:
+    from lib_controlnet.logging import logger
+
+    print = logger.info
+except ImportError:
+    pass
+
+models_path = preprocessor_dir
+clip_vision_path = os.path.join(preprocessor_dir, "clip_vision")
+
+os.makedirs(models_path, exist_ok=True)
+os.makedirs(clip_vision_path, exist_ok=True)
+
+print(f"Preprocessor location: {models_path}")
+# This file is here to satisfy the import made by the ln 8 in __init__.py, and 
+# is a copy of /forge_legacy_preprocessors/annotators/annotator_path.py

--- a/extensions-builtin/forge_preprocessor_normaldsine/annotator/normaldsine/LICENSE
+++ b/extensions-builtin/forge_preprocessor_normaldsine/annotator/normaldsine/LICENSE
@@ -1,0 +1,230 @@
+DSINE SOFTWARE
+
+LICENCE AGREEMENT
+
+WE (Imperial College of Science, Technology and Medicine, (“Imperial College
+London”)) ARE WILLING TO LICENSE THIS SOFTWARE TO YOU (a licensee “You”) ONLY
+ON THE CONDITION THAT YOU ACCEPT ALL OF THE TERMS CONTAINED IN THE FOLLOWING
+AGREEMENT. PLEASE READ THE AGREEMENT CAREFULLY BEFORE DOWNLOADING THE SOFTWARE.
+BY EXERCISING THE OPTION TO DOWNLOAD THE SOFTWARE YOU AGREE TO BE BOUND BY THE
+TERMS OF THE AGREEMENT.
+
+SOFTWARE LICENCE AGREEMENT (EXCLUDING BSD COMPONENTS)
+
+1. This Agreement pertains to a worldwide, non-exclusive, temporary, fully
+paid-up, royalty free, non-transferable, non-sub- licensable licence (the
+“Licence”) to use the elastic fusion source code, including any modification,
+part or derivative (the “Software”).
+
+Ownership and Licence. Your rights to use and download the Software onto your
+computer, and all other copies that You are authorised to make, are specified
+in this Agreement. However, we (or our licensors) retain all rights, including
+but not limited to all copyright and other intellectual property rights
+anywhere in the world, in the Software not expressly granted to You in this
+Agreement.
+
+2. Permitted use of the Licence:
+
+(a) You may download and install the Software onto one computer or server for
+use in accordance with Clause 2(b) of this Agreement provided that You ensure
+that the Software is not accessible by other users unless they have themselves
+accepted the terms of this licence agreement.
+
+(b) You may use the Software solely for non-commercial, internal  or academic
+research purposes and only in accordance with the terms of this Agreement. You
+may not use the Software for commercial purposes, including but not limited to
+(1) integration of all or part of the source code or the Software into a
+product for sale or licence by or on behalf of You to third parties or (2) use
+of the Software or any derivative of it for research to develop software
+products for sale or licence to a third party or (3) use of the Software or any
+derivative of it for research to develop non-software products for sale or
+licence to a third party, or (4) use of the Software to provide any service to
+an external organisation for which payment is received.
+
+Should You wish to use the Software for commercial purposes, You shall
+email researchcontracts.engineering@imperial.ac.uk .
+
+(c) Right to Copy. You may copy the Software for back-up and archival purposes,
+provided that each copy is kept in your possession and provided You reproduce
+our copyright notice (set out in Schedule 1) on each copy.
+
+(d) Transfer and sub-licensing. You may not rent, lend, or lease the Software
+and You may not transmit, transfer or sub-license this licence to use the
+Software or any of your rights or obligations under this Agreement to another
+party.
+
+(e) Identity of Licensee. The licence granted herein is personal to You. You
+shall not permit any third party to access, modify or otherwise use the
+Software nor shall You access modify or otherwise use the Software on behalf of
+any third party. If You wish to obtain a licence for mutiple users or a site
+licence for the Software please contact us
+at researchcontracts.engineering@imperial.ac.uk .
+
+(f) Publications and presentations. You may make public, results or data
+obtained from, dependent on or arising from research carried out using the
+Software, provided that any such presentation or publication identifies the
+Software as the source of the results or the data, including the Copyright
+Notice given in each element of the Software, and stating that the Software has
+been made available for use by You under licence from Imperial College London
+and You provide a copy of any such publication to Imperial College London.
+
+3. Prohibited Uses. You may not, without written permission from us
+at researchcontracts.engineering@imperial.ac.uk :
+
+(a) Use, copy, modify, merge, or transfer copies of the Software or any
+documentation provided by us which relates to the Software except as provided
+in this Agreement;
+
+(b) Use any back-up or archival copies of the Software (or allow anyone else to
+use such copies) for any purpose other than to replace the original copy in the
+event it is destroyed or becomes defective; or
+
+(c) Disassemble, decompile or "unlock", reverse translate, or in any manner
+decode the Software for any reason.
+
+4. Warranty Disclaimer
+
+(a) Disclaimer. The Software has been developed for research purposes only. You
+acknowledge that we are providing the Software to You under this licence
+agreement free of charge and on condition that the disclaimer set out below
+shall apply. We do not represent or warrant that the Software as to: (i) the
+quality, accuracy or reliability of the Software; (ii) the suitability of the
+Software for any particular use or for use under any specific conditions; and
+(iii) whether use of the Software will infringe third-party rights.
+
+You acknowledge that You have reviewed and evaluated the Software to determine
+that it meets your needs and that You assume all responsibility and liability
+for determining the suitability of the Software as fit for your particular
+purposes and requirements. Subject to Clause 4(b), we exclude and expressly
+disclaim all express and implied representations, warranties, conditions and
+terms not stated herein (including the implied conditions or warranties of
+satisfactory quality, merchantable quality, merchantability and fitness for
+purpose).
+
+(b) Savings. Some jurisdictions may imply warranties, conditions or terms or
+impose obligations upon us which cannot, in whole or in part, be excluded,
+restricted or modified or otherwise do not allow the exclusion of implied
+warranties, conditions or terms, in which case the above warranty disclaimer
+and exclusion will only apply to You to the extent permitted in the relevant
+jurisdiction and does not in any event exclude any implied warranties,
+conditions or terms which may not under applicable law be excluded.
+
+(c) Imperial College London disclaims all responsibility for the use which is
+made of the Software and any liability for the outcomes arising from using the
+Software.
+
+5. Limitation of Liability
+
+(a) You acknowledge that we are providing the Software to You under this
+licence agreement free of charge and on condition that the limitation of
+liability set out below shall apply. Accordingly, subject to Clause 5(b), we
+exclude all liability whether in contract, tort, negligence or otherwise, in
+respect of the Software and/or any related documentation provided to You by us
+including, but not limited to, liability for loss or corruption of data, loss
+of contracts, loss of income, loss of profits, loss of cover and any
+consequential or indirect loss or damage of any kind arising out of or in
+connection with this licence agreement, however caused. This exclusion shall
+apply even if we have been advised of the possibility of such loss or damage.
+
+(b) You agree to indemnify Imperial College London and hold it harmless from
+and against any and all claims, damages and liabilities asserted by third
+parties (including claims for negligence) which arise directly or indirectly
+from the use of the Software or any derivative of it or the sale of any
+products based on the Software. You undertake to make no liability claim
+against any employee, student, agent or appointee of Imperial College London,
+in connection with this Licence or the Software.
+
+(c) Nothing in this Agreement shall have the effect of excluding or limiting
+our statutory liability.
+
+(d) Some jurisdictions do not allow these limitations or exclusions either
+wholly or in part, and, to that extent, they may not apply to you. Nothing in
+this licence agreement will affect your statutory rights or other relevant
+statutory provisions which cannot be excluded, restricted or modified, and its
+terms and conditions must be read and construed subject to any such statutory
+rights and/or provisions.
+
+6. Confidentiality. You agree not to disclose any confidential information
+provided to You by us pursuant to this Agreement to any third party without our
+prior written consent. The obligations in this Clause 6 shall survive the
+termination of this Agreement for any reason.
+
+7. Termination.
+
+(a) We may terminate this licence agreement and your right to use the Software
+at any time with immediate effect upon written notice to You.
+
+(b) This licence agreement and your right to use the Software automatically
+terminate if You:
+
+  (i) fail to comply with any provisions of this Agreement; or
+
+  (ii) destroy the copies of the Software in your possession, or voluntarily
+  return the Software to us.
+
+(c) Upon termination You will destroy all copies of the Software.
+
+(d) Otherwise, the restrictions on your rights to use the Software will expire
+10 (ten) years after first use of the Software under this licence agreement.
+
+8. Miscellaneous Provisions.
+
+(a) This Agreement will be governed by and construed in accordance with the
+substantive laws of England and Wales whose courts shall have exclusive
+jurisdiction over all disputes which may arise between us.
+
+(b) This is the entire agreement between us relating to the Software, and
+supersedes any prior purchase order, communications, advertising or
+representations concerning the Software.
+
+(c) No change or modification of this Agreement will be valid unless it is in
+writing, and is signed by us.
+
+(d) The unenforceability or invalidity of any part of this Agreement will not
+affect the enforceability or validity of the remaining parts.
+
+BSD Elements of the Software
+
+For BSD elements of the Software, the following terms shall apply:
+Copyright as indicated in the header of the individual element of the Software.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+SCHEDULE 1
+
+The Software
+
+DSINE is a framework for estimating surface normals from a single image. It is based on the techniques described in the following publication:
+
+    • Gwangbin Bae, Andrew J. Davison. Rethinking Inductive Biases for Surface Normal Estimation. CVPR, 2024
+_________________________
+
+Acknowledgments
+
+If you use the software, you should reference the following paper in any publication:
+ 
+    • Gwangbin Bae, Andrew J. Davison. Rethinking Inductive Biases for Surface Normal Estimation. CVPR, 2024

--- a/extensions-builtin/forge_preprocessor_normaldsine/annotator/normaldsine/__init__.py
+++ b/extensions-builtin/forge_preprocessor_normaldsine/annotator/normaldsine/__init__.py
@@ -1,0 +1,74 @@
+import os
+import torch
+import torch.nn.functional as F
+import numpy as np
+
+from einops import rearrange
+from modules import devices
+from annotator.annotator_path import models_path
+import torchvision.transforms as transforms
+
+# There's no auto install set up
+# You have to install the wheel manually form here:
+# https://github.com/sdbds/DSINE/releases/download/1.0.2/dsine-2024.3.23-py3-none-any.whl
+import dsine.utils.utils as utils
+from dsine.models.dsine import DSINE
+
+from modules_forge.forge_util import resize_image_with_pad
+
+
+class NormalDsineDetector:
+    model_dir = os.path.join(models_path, "normal_dsine")
+
+    def __init__(self):
+        self.model = None
+        self.device = devices.get_device_for("controlnet")
+
+    def load_model(self):
+        remote_model_path = "https://huggingface.co/bdsqlsz/qinglong_controlnet-lllite/resolve/main/Annotators/dsine.pt"
+        modelpath = os.path.join(self.model_dir, "dsine.pt")
+        if not os.path.exists(modelpath):
+            from modules.modelloader import load_file_from_url
+            load_file_from_url(remote_model_path, model_dir=self.model_dir)
+        model = DSINE()
+        model.pixel_coords = model.pixel_coords.to(self.device)
+        model = utils.load_checkpoint(modelpath, model)
+        model.eval()
+        self.model = model.to(self.device)
+        self.norm = transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
+
+    def unload_model(self):
+        if self.model is not None:
+            self.model.cpu()
+
+    def __call__(self, input_image, new_fov=60.0, iterations=5, resulotion=512):
+        if self.model is None:
+            self.load_model()
+
+        self.model.to(self.device)
+        self.model.num_iter = iterations
+        orig_H, orig_W = input_image.shape[:2]
+        l, r, t, b = utils.pad_input(orig_H, orig_W)
+        input_image, remove_pad = resize_image_with_pad(input_image, resulotion)
+        assert input_image.ndim == 3
+        image_normal = input_image
+        with torch.no_grad():
+            image_normal = torch.from_numpy(image_normal).float().to(self.device)
+            image_normal = image_normal / 255.0
+            image_normal = rearrange(image_normal, 'h w c -> 1 c h w')
+            image_normal = self.norm(image_normal)
+            
+            intrins = utils.get_intrins_from_fov(new_fov=new_fov, H=orig_H, W=orig_W, device=self.device).unsqueeze(0)
+            
+            intrins[:, 0, 2] += l
+            intrins[:, 1, 2] += t
+            
+            normal = self.model(image_normal, intrins=intrins)[-1]
+            normal = normal[:, :, t:t+orig_H, l:l+orig_W]
+
+            normal = ((normal + 1) * 0.5).clip(0, 1)
+
+            normal = rearrange(normal[0], 'c h w -> h w c').cpu().numpy()
+            normal_image = (normal * 255.0).clip(0, 255).astype(np.uint8)
+
+            return remove_pad(normal_image)

--- a/extensions-builtin/forge_preprocessor_normaldsine/scripts/preprocessor_normaldsine.py
+++ b/extensions-builtin/forge_preprocessor_normaldsine/scripts/preprocessor_normaldsine.py
@@ -1,0 +1,62 @@
+from modules_forge.supported_preprocessor import Preprocessor, PreprocessorParameter
+from modules_forge.shared import preprocessor_dir, add_supported_preprocessor
+from modules_forge.forge_util import resize_image_with_pad
+from modules.modelloader import load_file_from_url
+
+import types
+import torch
+import numpy as np
+
+from einops import rearrange
+from annotator.normalbae.models.NNET import NNET
+from annotator.normalbae import load_checkpoint
+from torchvision import transforms
+
+
+class PreprocessorNormalBae(Preprocessor):
+    def __init__(self):
+        super().__init__()
+        self.name = 'normal_dsine'
+        self.tags = ['NormalMap']
+        self.model_filename_filters = ['normal']
+        self.slider_resolution = PreprocessorParameter(
+            label='Resolution', minimum=128, maximum=2048, value=512, step=16, visible=True)
+        self.slider_1 = PreprocessorParameter(
+            minimum=0,
+            maximum=360,
+            step=0.1,
+            value=60,
+            label="Fov",
+            visible=True,
+        )
+        self.slider_2 = PreprocessorParameter(
+            minimum=1,
+            maximum=20,
+            step=1,
+            value=5,
+            label="Iterations",
+            visible=True,
+        )
+        self.slider_3 = PreprocessorParameter(visible=False)
+        self.show_control_mode = True
+        self.do_not_need_model = False
+        self.model = None
+        self.sorting_priority = 100  # higher goes to top in the list
+
+    def __call__(self, input_image, resolution, slider_1=None, slider_2=None, slider_3=None, **kwargs):
+    
+        if self.model is None:
+            from annotator.normaldsine import NormalDsineDetector
+
+            self.model = NormalDsineDetector()
+
+        result = self.model(
+            input_image,
+            new_fov=float(slider_1),
+            iterations=int(slider_2),
+            resulotion=resolution,
+        )
+        return result
+
+
+add_supported_preprocessor(PreprocessorNormalBae())


### PR DESCRIPTION
Hey, here's a quick hack I put together to add normaldsine as a preprocessor for ControlNet.

I originally made this just for my own use, but figured it might be a decent addition to the repo, so I decided to create this PR.

Just a heads-up if you decide to include it: there are still some bugs I haven't had time to fix. (And probably won't have, since it's exams season for me)

### **Known issues:**

- I duplicated **annotator_path.py** as a quick fix for an import error.
- There's no auto-installer for the Dsine wheel.
- In 'inpaint, only masked' mode, using resolutions other than 512px makes the annotator generate a normal map in the wrong place"