### PR TITLE
Allow SageAttention2 backing function to be selected via options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ The name "Forge" is inspired by "Minecraft Forge". This project aims to become t
 - [X] Update to latest PyTorch
     - `torch==2.7.0+cu128`
     - `xformers==0.0.30`
+
+> [!Tip]
+> If your GPU does not support the latest PyTorch, manually [install](#install-older-pytorch) older version of PyTorch
+
 - [X] No longer install `open-clip` twice
 - [X] Update some packages to newer versions
 - [X] Update recommended Python to `3.11.9`
@@ -194,6 +198,12 @@ The name "Forge" is inspired by "Minecraft Forge". This project aims to become t
 > [!Important]
 > Using `symlink` means it will directly access the packages from the cache folders; refrain from clearing the cache when setting this option
 
+- `--model-ref`: Points to a central `models` folder that contains all your models
+    - said folder should contain subfolders like `Stable-diffusion`, `Lora`, `VAE`, `ESRGAN`, etc.
+
+> [!Important]
+> This simply **replaces** the `models` folder, rather than adding on top of it
+
 - `--fast-fp16`: Enable the `allow_fp16_accumulation` option
     - requires PyTorch **2.7.0** +
 - `--sage`: Install the `sageattention` package to speed up generation
@@ -201,14 +211,21 @@ The name "Forge" is inspired by "Minecraft Forge". This project aims to become t
     - requires RTX **30** +
     - only affects **SDXL**
 
-> [!Tip]
-> `--xformers` is still recommended even if you already have `--sage`, as `sageattention` does not speed up **VAE** while `xformers` does
+> [!Note]
+> For RTX **50** users, you may need to manually [install](#install-sageattention-2) `sageattention 2` instead
 
-- `--model-ref`: Points to a central `models` folder that contains all your models
-    - said folder should contain subfolders like `Stable-diffusion`, `Lora`, `VAE`, `ESRGAN`, etc.
+<details>
+<summary>with SageAttention 2</summary>
 
-> [!Important]
-> This simply **replaces** the `models` folder, rather than adding on top of it
+- `--sageattn2-api`: Select the function used by **SageAttention 2**
+    - **options:**
+        - `auto` (default)
+        - `triton-fp16`
+        - `cuda-fp16`
+        - `cuda-fp8`
+    - try the `fp16` options if you get `NaN` *(black images)* on `auto`
+
+</details>
 
 <br>
 
@@ -342,7 +359,6 @@ The name "Forge" is inspired by "Minecraft Forge". This project aims to become t
 </details>
 
 ### Install sageattention 2
-> If you only use **SDXL**, then `1.x` is already enough; `2.x` simply has partial support for **SD1** checkpoints
 
 <details>
 <summary>Expand</summary>
@@ -376,10 +392,7 @@ The name "Forge" is inspired by "Minecraft Forge". This project aims to become t
 
 </details>
 
-<br>
-
 ### Install older PyTorch
-> Read this if your GPU does not support the latest PyTorch
 
 <details>
 <summary>Expand</summary>
@@ -398,7 +411,7 @@ set TORCH_COMMAND=pip install torch==2.1.2 torchvision==0.16.2 --extra-index-url
 ## Attention
 
 > [!Important]
-> The `--xformers` and `--sage` args are only responsible for installing the packages, **not** whether its respective attention is used; This also means you can remove them once they are successfully installed
+> The `--xformers` and `--sage` args are only responsible for installing the packages, **not** whether its respective attention is used *(this also means you can remove them once the packages are successfully installed)*
 
 **Forge Classic** tries to import the packages and automatically choose the first available attention function in the following order:
 
@@ -408,8 +421,11 @@ set TORCH_COMMAND=pip install torch==2.1.2 torchvision==0.16.2 --extra-index-url
 4. `PyTorch`
 5. `Basic`
 
+> [!Tip]
+> To skip a specific attention, add the respective disable arg such as `--disable-sage`
+
 > [!Note]
-> The VAE only checks for `xformers`
+> The **VAE** only checks for `xformers`, so `--xformers` is still recommended even if you already have `--sage`
 
 In my experience, the speed of each attention function for SDXL is ranked in the following order:
 
@@ -417,6 +433,8 @@ In my experience, the speed of each attention function for SDXL is ranked in the
 
 > [!Note]
 > `SageAttention` is based on quantization, so its quality might be slightly worse than others
+
+<br>
 
 ## Issues & Requests
 

--- a/ldm_patched/ldm/modules/attention.py
+++ b/ldm_patched/ldm/modules/attention.py
@@ -13,6 +13,7 @@ import torch.nn.functional as F
 from einops import rearrange, repeat
 from ldm_patched.modules import model_management
 from torch import einsum, nn
+from modules.shared import opts
 
 from .diffusionmodules.util import AlphaBlender, checkpoint, timestep_embedding
 
@@ -21,6 +22,14 @@ if model_management.sage_enabled():
     from sageattention import sageattn
 
     isSage2 = importlib.metadata.version("sageattention").startswith("2")
+
+    if isSage2:
+        from sageattention import sageattn_qk_int8_pv_fp16_triton, sageattn_qk_int8_pv_fp16_cuda, sageattn_qk_int8_pv_fp8_cuda
+        sage2api_dispatch = {
+            "Triton fp16": lambda q, k, v: sageattn_qk_int8_pv_fp16_triton(q, k, v, tensor_layout="NHD", is_causal=False),
+            "CUDA fp16": lambda q, k, v: sageattn_qk_int8_pv_fp16_cuda(q, k, v, tensor_layout="NHD", is_causal=False, qk_quant_gran="per_warp", pv_accum_dtype="fp16+fp32"),
+            "CUDA fp8": lambda q, k, v: sageattn_qk_int8_pv_fp8_cuda(q, k, v, tensor_layout="NHD", is_causal=False, qk_quant_gran="per_warp", pv_accum_dtype="fp32+fp32")
+        }
 
 if model_management.xformers_enabled():
     import xformers
@@ -222,8 +231,9 @@ def attention_sage(q, k, v, heads, mask=None):
 
     b, _, dim_head = q.shape
     dim_head //= heads
+    sage2Api = opts.sageattn2_api
 
-    if (isSage2 and dim_head > 128) or ((not isSage2) and (dim_head not in (64, 96, 128))):
+    if (isSage2 and (sage2Api == "Disabled" or dim_head > 128)) or ((not isSage2) and (dim_head not in (64, 96, 128))):
         if model_management.xformers_enabled():
             return attention_xformers(q, k, v, heads, mask)
         else:
@@ -240,7 +250,10 @@ def attention_sage(q, k, v, heads, mask=None):
         if mask.ndim == 3:
             mask = mask.unsqueeze(1)
 
-    out = sageattn(q, k, v, attn_mask=mask, is_causal=False, tensor_layout="NHD")
+    if isSage2 and sage2Api != "Automatic":
+        out = sage2api_dispatch.get(sage2Api)(q, k, v)
+    else:
+        out = sageattn(q, k, v, attn_mask=mask, is_causal=False, tensor_layout="NHD")
     return out.reshape(b, -1, heads * dim_head)
 
 

--- a/ldm_patched/ldm/modules/attention.py
+++ b/ldm_patched/ldm/modules/attention.py
@@ -13,7 +13,6 @@ import torch.nn.functional as F
 from einops import rearrange, repeat
 from ldm_patched.modules import model_management
 from torch import einsum, nn
-from modules.shared import opts
 
 from .diffusionmodules.util import AlphaBlender, checkpoint, timestep_embedding
 
@@ -23,14 +22,6 @@ if model_management.sage_enabled():
 
     isSage2 = importlib.metadata.version("sageattention").startswith("2")
 
-    if isSage2:
-        from sageattention import sageattn_qk_int8_pv_fp16_triton, sageattn_qk_int8_pv_fp16_cuda, sageattn_qk_int8_pv_fp8_cuda
-        sage2api_dispatch = {
-            "Triton fp16": lambda q, k, v: sageattn_qk_int8_pv_fp16_triton(q, k, v, tensor_layout="NHD", is_causal=False),
-            "CUDA fp16": lambda q, k, v: sageattn_qk_int8_pv_fp16_cuda(q, k, v, tensor_layout="NHD", is_causal=False, qk_quant_gran="per_warp", pv_accum_dtype="fp16+fp32"),
-            "CUDA fp8": lambda q, k, v: sageattn_qk_int8_pv_fp8_cuda(q, k, v, tensor_layout="NHD", is_causal=False, qk_quant_gran="per_warp", pv_accum_dtype="fp32+fp32")
-        }
-
 if model_management.xformers_enabled():
     import xformers
     import xformers.ops
@@ -39,9 +30,7 @@ if model_management.flash_enabled():
     from flash_attn import flash_attn_func
 
     @torch.library.custom_op("flash_attention::flash_attn", mutates_args=())
-    def flash_attn_wrapper(
-        q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, dropout_p: float = 0.0, causal: bool = False
-    ) -> torch.Tensor:
+    def flash_attn_wrapper(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, dropout_p: float = 0.0, causal: bool = False) -> torch.Tensor:
         return flash_attn_func(q, k, v, dropout_p=dropout_p, causal=causal)
 
     @flash_attn_wrapper.register_fake
@@ -50,7 +39,7 @@ if model_management.flash_enabled():
 
 
 import ldm_patched.modules.ops
-from ldm_patched.modules.args_parser import args
+from ldm_patched.modules.args_parser import args, SageAttentionAPIs
 
 ops = ldm_patched.modules.ops.disable_weight_init
 
@@ -113,11 +102,7 @@ class FeedForward(nn.Module):
         super().__init__()
         inner_dim = int(dim * mult)
         dim_out = default(dim_out, dim)
-        project_in = (
-            nn.Sequential(operations.Linear(dim, inner_dim, dtype=dtype, device=device), nn.GELU())
-            if not glu
-            else GEGLU(dim, inner_dim, dtype=dtype, device=device, operations=operations)
-        )
+        project_in = nn.Sequential(operations.Linear(dim, inner_dim, dtype=dtype, device=device), nn.GELU()) if not glu else GEGLU(dim, inner_dim, dtype=dtype, device=device, operations=operations)
 
         self.net = nn.Sequential(
             project_in,
@@ -147,11 +132,7 @@ def attention_basic(q, k, v, heads, mask=None):
 
     h = heads
     q, k, v = map(
-        lambda t: t.unsqueeze(3)
-        .reshape(b, -1, heads, dim_head)
-        .permute(0, 2, 1, 3)
-        .reshape(b * heads, -1, dim_head)
-        .contiguous(),
+        lambda t: t.unsqueeze(3).reshape(b, -1, heads, dim_head).permute(0, 2, 1, 3).reshape(b * heads, -1, dim_head).contiguous(),
         (q, k, v),
     )
 
@@ -223,6 +204,18 @@ def attention_xformers(q, k, v, heads, mask=None):
     return out.unsqueeze(0).reshape(b, heads, -1, dim_head).transpose(1, 2).reshape(b, -1, heads * dim_head)
 
 
+if isSage2 and args.sageattn2_api is not SageAttentionAPIs.Automatic:
+    from functools import partial
+    from sageattention import sageattn_qk_int8_pv_fp16_triton, sageattn_qk_int8_pv_fp16_cuda, sageattn_qk_int8_pv_fp8_cuda
+
+    if args.sageattn2_api is SageAttentionAPIs.fp16Triton:
+        sageattn = sageattn_qk_int8_pv_fp16_triton
+    if args.sageattn2_api is SageAttentionAPIs.fp16CUDA:
+        sageattn = partial(sageattn_qk_int8_pv_fp16_cuda, qk_quant_gran="per_warp", pv_accum_dtype="fp16+fp32")
+    if args.sageattn2_api is SageAttentionAPIs.fp8CUDA:
+        sageattn = partial(sageattn_qk_int8_pv_fp8_cuda, qk_quant_gran="per_warp", pv_accum_dtype="fp16+fp32")
+
+
 def attention_sage(q, k, v, heads, mask=None):
     """
     Reference: https://github.com/comfyanonymous/ComfyUI/blob/v0.3.13/comfy/ldm/modules/attention.py#L472
@@ -231,9 +224,8 @@ def attention_sage(q, k, v, heads, mask=None):
 
     b, _, dim_head = q.shape
     dim_head //= heads
-    sage2Api = opts.sageattn2_api
 
-    if (isSage2 and (sage2Api == "Disabled" or dim_head > 128)) or ((not isSage2) and (dim_head not in (64, 96, 128))):
+    if (isSage2 and dim_head > 128) or ((not isSage2) and (dim_head not in (64, 96, 128))):
         if model_management.xformers_enabled():
             return attention_xformers(q, k, v, heads, mask)
         else:
@@ -244,16 +236,9 @@ def attention_sage(q, k, v, heads, mask=None):
         (q, k, v),
     )
 
-    if mask is not None:
-        if mask.ndim == 2:
-            mask = mask.unsqueeze(0)
-        if mask.ndim == 3:
-            mask = mask.unsqueeze(1)
+    assert mask is None
 
-    if isSage2 and sage2Api != "Automatic":
-        out = sage2api_dispatch.get(sage2Api)(q, k, v)
-    else:
-        out = sageattn(q, k, v, attn_mask=mask, is_causal=False, tensor_layout="NHD")
+    out = sageattn(q, k, v, is_causal=False, tensor_layout="NHD")
     return out.reshape(b, -1, heads * dim_head)
 
 

--- a/ldm_patched/ldm/modules/attention.py
+++ b/ldm_patched/ldm/modules/attention.py
@@ -283,7 +283,16 @@ def attention_flash(q, k, v, heads, mask=None, attn_precision=None, skip_reshape
 
 
 if model_management.sage_enabled():
-    print("Using sage attention")
+    match args.sageattn2_api:
+        case SageAttentionAPIs.Automatic:
+            print("Using sage attention")
+        case SageAttentionAPIs.Triton16:
+            print("Using sage attention (Triton fp16)")
+        case SageAttentionAPIs.CUDA16:
+            print("Using sage attention (CUDA fp16)")
+        case SageAttentionAPIs.CUDA8:
+            print("Using sage attention (CUDA fp8)")
+
     optimized_attention = attention_sage
 elif model_management.flash_enabled():
     print("Using flash attention")

--- a/ldm_patched/ldm/modules/attention.py
+++ b/ldm_patched/ldm/modules/attention.py
@@ -208,11 +208,11 @@ if isSage2 and args.sageattn2_api is not SageAttentionAPIs.Automatic:
     from functools import partial
     from sageattention import sageattn_qk_int8_pv_fp16_triton, sageattn_qk_int8_pv_fp16_cuda, sageattn_qk_int8_pv_fp8_cuda
 
-    if args.sageattn2_api is SageAttentionAPIs.fp16Triton:
+    if args.sageattn2_api is SageAttentionAPIs.Triton16:
         sageattn = sageattn_qk_int8_pv_fp16_triton
-    if args.sageattn2_api is SageAttentionAPIs.fp16CUDA:
+    if args.sageattn2_api is SageAttentionAPIs.CUDA16:
         sageattn = partial(sageattn_qk_int8_pv_fp16_cuda, qk_quant_gran="per_warp", pv_accum_dtype="fp16+fp32")
-    if args.sageattn2_api is SageAttentionAPIs.fp8CUDA:
+    if args.sageattn2_api is SageAttentionAPIs.CUDA8:
         sageattn = partial(sageattn_qk_int8_pv_fp8_cuda, qk_quant_gran="per_warp", pv_accum_dtype="fp16+fp32")
 
 

--- a/ldm_patched/modules/args_parser.py
+++ b/ldm_patched/modules/args_parser.py
@@ -81,9 +81,9 @@ parser.add_argument("--fast-fp16", action="store_true")
 
 class SageAttentionAPIs(enum.Enum):
     Automatic = "auto"
-    fp16Triton = "triton-fp16"
-    fp16CUDA = "cuda-fp16"
-    fp8CUDA = "cuda-fp8"
+    Triton16 = "triton-fp16"
+    CUDA16 = "cuda-fp16"
+    CUDA8 = "cuda-fp8"
 
 
 parser.add_argument("--sageattn2-api", type=SageAttentionAPIs, default=SageAttentionAPIs.Automatic, action=EnumAction)

--- a/ldm_patched/modules/args_parser.py
+++ b/ldm_patched/modules/args_parser.py
@@ -2,6 +2,26 @@
 
 
 import argparse
+import enum
+
+
+class EnumAction(argparse.Action):
+    """Argparse `action` for handling Enum"""
+
+    def __init__(self, **kwargs):
+        enum_type = kwargs.pop("type", None)
+        assert issubclass(enum_type, enum.Enum)
+
+        choices = tuple(e.value for e in enum_type)
+        kwargs.setdefault("choices", choices)
+        kwargs.setdefault("metavar", f"[{','.join(list(choices))}]")
+
+        super(EnumAction, self).__init__(**kwargs)
+        self._enum = enum_type
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        value = self._enum(values)
+        setattr(namespace, self.dest, value)
 
 
 parser = argparse.ArgumentParser()
@@ -57,5 +77,16 @@ parser.add_argument("--cuda-stream", action="store_true")
 parser.add_argument("--pin-shared-memory", action="store_true")
 
 parser.add_argument("--fast-fp16", action="store_true")
+
+
+class SageAttentionAPIs(enum.Enum):
+    Automatic = "auto"
+    fp16Triton = "triton-fp16"
+    fp16CUDA = "cuda-fp16"
+    fp8CUDA = "cuda-fp8"
+
+
+parser.add_argument("--sageattn2-api", type=SageAttentionAPIs, default=SageAttentionAPIs.Automatic, action=EnumAction)
+
 
 args = parser.parse_args([])

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -241,7 +241,6 @@ options_templates.update(
         ("optimizations", "Optimizations", "sd"),
         {
             "cross_attention_optimization": OptionInfo("Automatic", "Cross attention optimization", gr.Dropdown, lambda: {"choices": ["Automatic"], "interactive": False}),
-            "sageattn2_api": OptionInfo("Automatic", "SageAttention2 API", gr.Radio, {"choices": ["Automatic", "Triton fp16", "CUDA fp16", "CUDA fp8", "Disabled"]}).info("function used by <b>SageAttention2</b> if installed and enabled; try the fp16 options if you get black images; disabled will use PyTorch/xFormers"),
             "s_min_uncond": OptionInfo(0.0, "Negative Guidance minimum sigma", gr.Slider, {"minimum": 0.0, "maximum": 8.0, "step": 0.05}).link("PR", "https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/9177").info("skip negative prompt for some steps when the image is almost ready; 0=disable; higher=faster"),
             "skip_early_cond": OptionInfo(0.0, "Ignore negative prompt during early steps", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.05}, infotext="Skip Early CFG").info("disables CFG on a proportion of steps at the beginning of generation; 0=disable; 1=skip all; can both improve sample diversity/quality and speed up sampling"),
             "persistent_cond_cache": OptionInfo(True, "Persistent cond cache").info("do not recalculate conds from prompts if prompts have not changed since previous calculation"),

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -241,6 +241,7 @@ options_templates.update(
         ("optimizations", "Optimizations", "sd"),
         {
             "cross_attention_optimization": OptionInfo("Automatic", "Cross attention optimization", gr.Dropdown, lambda: {"choices": ["Automatic"], "interactive": False}),
+            "sageattn2_api": OptionInfo("Automatic", "SageAttention2 API", gr.Radio, {"choices": ["Automatic", "Triton fp16", "CUDA fp16", "CUDA fp8", "Disabled"]}).info("function used by <b>SageAttention2</b> if installed and enabled; try the fp16 options if you get black images; disabled will use PyTorch/xFormers"),
             "s_min_uncond": OptionInfo(0.0, "Negative Guidance minimum sigma", gr.Slider, {"minimum": 0.0, "maximum": 8.0, "step": 0.05}).link("PR", "https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/9177").info("skip negative prompt for some steps when the image is almost ready; 0=disable; higher=faster"),
             "skip_early_cond": OptionInfo(0.0, "Ignore negative prompt during early steps", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.05}, infotext="Skip Early CFG").info("disables CFG on a proportion of steps at the beginning of generation; 0=disable; 1=skip all; can both improve sample diversity/quality and speed up sampling"),
             "persistent_cond_cache": OptionInfo(True, "Persistent cond cache").info("do not recalculate conds from prompts if prompts have not changed since previous calculation"),


### PR DESCRIPTION
Allow the user to manually select the function call used by SageAttention2, rather than relying on the auto-detection within the core `sageattn` function based on `torch.cuda.get_device_capability`.

![image](https://github.com/user-attachments/assets/0b556d8f-708b-451e-956e-0d3046890fc8)

Along with allowing the default "Automatic" option, we also include the ability to disable Sage2, which will fall back to xFormers or PyTorch (whichever is available). In my particular case, despite having a 4090 Mobile, which should handled fp8 fine, using it in conjunction with an empty negative prompt results in a black image. However, either of the fp16 options work fine.

The API calls differ slightly, mainly with the use of `per_warp`, which should provide marginally better performance, though I haven't noticed anything in testing.

This pull request hopefully addresses the issues some users are experiencing with SageAttention2 (myself included). It's not so much a fix as a workaround.

Relevant issues:
https://github.com/Haoming02/sd-webui-forge-classic/issues/43
https://github.com/Haoming02/sd-webui-forge-classic/issues/19

Side note: I've noticed that Sage2 has no support for masks, so not sure if the fallback should be use if a mask is detected as well.