### PR TITLE
Ignore LoRAs if prompt weight is zero.

### DIFF
--- a/extensions-builtin/Lora/extra_networks_lora.py
+++ b/extensions-builtin/Lora/extra_networks_lora.py
@@ -23,10 +23,10 @@ class ExtraNetworkLora(extra_networks.ExtraNetwork):
         te_multipliers = []
         unet_multipliers = []
         dyn_dims = []
+        skipped_loras = []
+
         for params in params_list:
             assert params.items
-
-            names.append(params.positional[0])
 
             te_multiplier = float(params.positional[1]) if len(params.positional) > 1 else 1.0
             te_multiplier = float(params.named.get("te", te_multiplier))
@@ -37,9 +37,16 @@ class ExtraNetworkLora(extra_networks.ExtraNetwork):
             dyn_dim = int(params.positional[3]) if len(params.positional) > 3 else None
             dyn_dim = int(params.named["dyn"]) if "dyn" in params.named else dyn_dim
 
-            te_multipliers.append(te_multiplier)
-            unet_multipliers.append(unet_multiplier)
-            dyn_dims.append(dyn_dim)
+            if te_multiplier == 0.0 and unet_multiplier == 0.0:
+                skipped_loras.append(params.positional[0]);
+            else:
+                names.append(params.positional[0])
+                te_multipliers.append(te_multiplier)
+                unet_multipliers.append(unet_multiplier)
+                dyn_dims.append(dyn_dim)
+
+        if skipped_loras:
+            print(f"\n[LORA] Ignoring: {', '.join(skipped_loras)}. Multipliers are 0.")
 
         networks.load_networks(names, te_multipliers, unet_multipliers, dyn_dims)
 

--- a/extensions-builtin/Lora/extra_networks_lora.py
+++ b/extensions-builtin/Lora/extra_networks_lora.py
@@ -23,8 +23,6 @@ class ExtraNetworkLora(extra_networks.ExtraNetwork):
         te_multipliers = []
         unet_multipliers = []
         dyn_dims = []
-        skipped_loras = []
-
         for params in params_list:
             assert params.items
 
@@ -34,19 +32,16 @@ class ExtraNetworkLora(extra_networks.ExtraNetwork):
             unet_multiplier = float(params.positional[2]) if len(params.positional) > 2 else te_multiplier
             unet_multiplier = float(params.named.get("unet", unet_multiplier))
 
+            if te_multiplier == 0.0 and unet_multiplier == 0.0:
+                continue
+
             dyn_dim = int(params.positional[3]) if len(params.positional) > 3 else None
             dyn_dim = int(params.named["dyn"]) if "dyn" in params.named else dyn_dim
 
-            if te_multiplier == 0.0 and unet_multiplier == 0.0:
-                skipped_loras.append(params.positional[0]);
-            else:
-                names.append(params.positional[0])
-                te_multipliers.append(te_multiplier)
-                unet_multipliers.append(unet_multiplier)
-                dyn_dims.append(dyn_dim)
-
-        if skipped_loras:
-            print(f"\n[LORA] Ignoring: {', '.join(skipped_loras)}. Multipliers are 0.")
+            names.append(params.positional[0])
+            te_multipliers.append(te_multiplier)
+            unet_multipliers.append(unet_multiplier)
+            dyn_dims.append(dyn_dim)
 
         networks.load_networks(names, te_multipliers, unet_multipliers, dyn_dims)
 


### PR DESCRIPTION
Ignore any LoRAs specified in prompts that have zero weight. For example `<lora:name:0.0>` or `<lora:name:te=0:unet=0>`.

Default behaviour is still to add the weights from the LoRA, even though they'll be multiplied by zero and have no effect on the output. This can slow down processing noticeably when multiple zero-weight LoRAs are specified.

I'm not sure how common it is, but I tend to set LoRA weights to zero but keep them in the prompts while I'm experimenting. The alternative is to delete the LoRA, then re-add it, which is a bit of a pain. So while this doesn't have an impact on regular LoRA usage, it should make tweaking prompts snappier.

I've included a print statement informing the user of which LoRAs were skipped, just as a courtesy.