### PR TITLE
Performance: Experimental persistent LoRA patching

### DIFF
--- a/ldm_patched/modules/model_management.py
+++ b/ldm_patched/modules/model_management.py
@@ -369,7 +369,7 @@ class LoadedModel:
     def model_memory_required(self, device: torch.device) -> int:
         return module_size(self.model.model, exclude_device=device)
 
-    def model_load(self, async_kept_memory: int = -1):
+    def model_load(self, async_kept_memory: int = -1, allow_persistent_loras: bool = False):
         patch_model_to = None
         disable_async_load = async_kept_memory < 0
 
@@ -381,7 +381,7 @@ class LoadedModel:
 
         try:
             # TODO: do something with loras and offloading to CPU
-            self.real_model = self.model.patch_model(device_to=patch_model_to)
+            self.real_model = self.model.patch_model(device_to=patch_model_to, allow_persistent_loras=allow_persistent_loras)
         except Exception as e:
             self.model.unpatch_model(self.model.offload_device)
             self.model_unload()
@@ -434,7 +434,7 @@ class LoadedModel:
 
         return self.real_model
 
-    def model_unload(self, avoid_model_moving: bool = False):
+    def model_unload(self, avoid_model_moving: bool = False, allow_persistent_loras: bool = False):
         if self.model_accelerated:
             for m in self.real_model.modules():
                 if hasattr(m, "prev_ldm_patched_cast_weights"):
@@ -444,9 +444,9 @@ class LoadedModel:
             self.model_accelerated = False
 
         if avoid_model_moving:
-            self.model.unpatch_model()
+            self.model.unpatch_model(allow_persistent_loras=allow_persistent_loras)
         else:
-            self.model.unpatch_model(self.model.offload_device)
+            self.model.unpatch_model(self.model.offload_device, allow_persistent_loras=allow_persistent_loras)
             self.model.model_patches_to(self.model.offload_device)
 
     def __eq__(self, other: "LoadedModel"):
@@ -460,18 +460,17 @@ def minimum_inference_memory():
     return 1024 * 1024 * 1024
 
 
-def unload_model_clones(model):
+def unload_model_clones(model, allow_persistent_loras=False):
     to_unload = [i for i in range(len(current_loaded_models)) if model.is_clone(current_loaded_models[i].model)]
 
     for i in reversed(to_unload):
         m = current_loaded_models.pop(i)
-        m.model_unload(avoid_model_moving=True)
+        m.model_unload(avoid_model_moving=True, allow_persistent_loras=allow_persistent_loras)
         del m
 
     if len(to_unload) > 0:
         print(f"Reusing {len(to_unload)} loaded model{'s' if len(to_unload) > 1 else ''}")
         soft_empty_cache()
-        gc.collect()
 
 
 def free_memory(memory_required, device, keep_loaded=[]):
@@ -505,6 +504,16 @@ def load_models_gpu(models, memory_required=0):
     models_to_load = []
     models_already_loaded = []
 
+    from modules import shared
+    allow_persistent_loras = shared.opts.persistent_patches
+
+    if allow_persistent_loras:
+        # Disable persistent patches if no LoRAs are active, so model is unpatched correctly. We do
+        # because add_patches is not called otherwise, and our rolling hash will be incorrect.
+        from modules import sd_models
+        current_sd = sd_models.model_data.get_sd_model()
+        allow_persistent_loras = current_sd is not None and current_sd.current_lora_hash != '[]'
+
     for x in models:
         load_model = LoadedModel(x, memory_required=memory_required)
 
@@ -534,7 +543,7 @@ def load_models_gpu(models, memory_required=0):
 
     total_memory_required = {}
     for loaded_model in models_to_load:
-        unload_model_clones(loaded_model.model)
+        unload_model_clones(loaded_model.model, allow_persistent_loras=allow_persistent_loras)
         mem = total_memory_required.get(loaded_model.device, 0) + loaded_model.model_memory_required(loaded_model.device)
         total_memory_required[loaded_model.device] = mem
 
@@ -575,7 +584,7 @@ def load_models_gpu(models, memory_required=0):
         if vram_set_state is VRAMState.NO_VRAM:
             async_kept_memory = 0
 
-        loaded_model.model_load(async_kept_memory)
+        loaded_model.model_load(async_kept_memory, allow_persistent_loras=allow_persistent_loras)
         current_loaded_models.insert(0, loaded_model)
 
     moving_time = time.perf_counter() - execution_start_time

--- a/ldm_patched/modules/model_management.py
+++ b/ldm_patched/modules/model_management.py
@@ -509,7 +509,7 @@ def load_models_gpu(models, memory_required=0):
 
     if allow_persistent_loras:
         # Disable persistent patches if no LoRAs are active, so model is unpatched correctly. We do
-        # because add_patches is not called otherwise, and our rolling hash will be incorrect.
+        # this because add_patches won't be called, and the incrementing version will be incorrect.
         from modules import sd_models
         current_sd = sd_models.model_data.get_sd_model()
         allow_persistent_loras = current_sd is not None and current_sd.current_lora_hash != '[]'

--- a/ldm_patched/modules/model_patcher.py
+++ b/ldm_patched/modules/model_patcher.py
@@ -205,7 +205,7 @@ class ModelPatcher:
                 self.patches[k] = current_patches
 
         h = hashlib.md5()
-        h.update(bytes.fromhex(self.running_patches_hash or "DEADBEEF" * 16))
+        h.update(bytes.fromhex(self.running_patches_hash or "DEADBEEF" * 4))
         h.update(f"{patch_key}|{strength_patch!r}|{strength_model!r}".encode())
         self.running_patches_hash = h.hexdigest()
 

--- a/ldm_patched/modules/model_patcher.py
+++ b/ldm_patched/modules/model_patcher.py
@@ -30,7 +30,7 @@ class ModelPatcher:
             self.current_device = current_device
 
         self.weight_inplace_update = weight_inplace_update
-        self.patches_version = { "running": 0, "current": 0 }
+        self.patches_version = {"running": 0, "current": 0}
 
     def model_size(self):
         if self.size > 0:
@@ -206,44 +206,42 @@ class ModelPatcher:
                 self.object_patches_backup[k] = old
             ldm_patched.modules.utils.set_attr_raw(self.model, k, self.object_patches[k])
 
-        if patch_weights:
-            do_patch = (
-                (not allow_persistent_loras) or
-                (self.patches and self.patches_version["current"] == 0)
-            )
+        if not patch_weights:
+            return self.model
 
-            if do_patch:
-                model_sd = self.model_state_dict()
-                
-                for key in self.patches:
-                    if key not in model_sd:
-                        print(f'Could not patch as "{key}" does not exist in model...')
-                        continue
+        do_patch = (not allow_persistent_loras) or (self.patches and self.patches_version["current"] == 0)
 
-                    weight = model_sd[key]
+        if do_patch:
+            model_sd = self.model_state_dict()
+            for key in self.patches:
+                if key not in model_sd:
+                    print(f'Could not patch as "{key}" does not exist in model...')
+                    continue
 
-                    inplace_update = self.weight_inplace_update
+                weight = model_sd[key]
 
-                    if key not in self.backup:
-                        self.backup[key] = weight.to(device=self.offload_device, copy=inplace_update)
+                inplace_update = self.weight_inplace_update
 
-                    if device_to is not None:
-                        temp_weight = ldm_patched.modules.model_management.cast_to_device(weight, device_to, torch.float32, copy=True)
-                    else:
-                        temp_weight = weight.to(torch.float32, copy=True)
-                    out_weight = self.calculate_weight(self.patches[key], temp_weight, key).to(weight.dtype)
-                    if inplace_update:
-                        ldm_patched.modules.utils.copy_to_param(self.model, key, out_weight)
-                    else:
-                        ldm_patched.modules.utils.set_attr(self.model, key, out_weight)
-                    del temp_weight
+                if key not in self.backup:
+                    self.backup[key] = weight.to(device=self.offload_device, copy=inplace_update)
 
-                if self.patches and self.patches_version["running"] != 0:
-                    self.patches_version["current"] = self.patches_version["running"]
+                if device_to is not None:
+                    temp_weight = ldm_patched.modules.model_management.cast_to_device(weight, device_to, torch.float32, copy=True)
+                else:
+                    temp_weight = weight.to(torch.float32, copy=True)
+                out_weight = self.calculate_weight(self.patches[key], temp_weight, key).to(weight.dtype)
+                if inplace_update:
+                    ldm_patched.modules.utils.copy_to_param(self.model, key, out_weight)
+                else:
+                    ldm_patched.modules.utils.set_attr(self.model, key, out_weight)
+                del temp_weight
 
-            if device_to is not None:
-                self.model.to(device_to)
-                self.current_device = device_to
+            if self.patches and self.patches_version["running"] != 0:
+                self.patches_version["current"] = self.patches_version["running"]
+
+        if device_to is not None:
+            self.model.to(device_to)
+            self.current_device = device_to
 
         return self.model
 
@@ -418,10 +416,7 @@ class ModelPatcher:
         return weight
 
     def unpatch_model(self, device_to=None, allow_persistent_loras=False):
-        do_unpatch = (
-            (not allow_persistent_loras) or
-            (self.backup and self.patches_version["current"] != self.patches_version["running"])
-        )
+        do_unpatch = (not allow_persistent_loras) or (self.backup and self.patches_version["current"] != self.patches_version["running"])
 
         if do_unpatch:
             keys = list(self.backup.keys())

--- a/ldm_patched/modules/model_patcher.py
+++ b/ldm_patched/modules/model_patcher.py
@@ -8,16 +8,26 @@ import inspect
 import ldm_patched.modules.model_management
 import ldm_patched.modules.utils
 import torch
+import hashlib
+import struct
 
 extra_weight_calculators = {}
 
+
+def rolling_md5(key, a, b, prev_digest):
+    h = hashlib.md5()
+    if prev_digest is None:
+        prev_digest = "DEADBEEF" * 16
+    h.update(bytes.fromhex(prev_digest))
+    h.update(key.encode('utf-8'))
+    h.update(struct.pack('>dd', a, b))
+    return h.hexdigest()
 
 class ModelPatcher:
     def __init__(self, model, load_device, offload_device, size=0, current_device=None, weight_inplace_update=False):
         self.size = size
         self.model = model
         self.patches = {}
-        self.backup = {}
         self.object_patches = {}
         self.object_patches_backup = {}
         self.model_options = {"transformer_options": {}}
@@ -30,6 +40,35 @@ class ModelPatcher:
             self.current_device = current_device
 
         self.weight_inplace_update = weight_inplace_update
+        self.patches_hash_info = {
+            "running_patches_hash": None,
+            "current_patches_hash": None,
+            "backup": {}
+        }
+
+    @property
+    def running_patches_hash(self):
+        return self.patches_hash_info["running_patches_hash"]
+
+    @running_patches_hash.setter
+    def running_patches_hash(self, value):
+        self.patches_hash_info["running_patches_hash"] = value
+
+    @property
+    def current_patches_hash(self):
+        return self.patches_hash_info["current_patches_hash"]
+
+    @current_patches_hash.setter
+    def current_patches_hash(self, value):
+        self.patches_hash_info["current_patches_hash"] = value
+
+    @property
+    def backup(self):
+        return self.patches_hash_info["backup"]
+
+    @backup.setter
+    def backup(self, value):
+        self.patches_hash_info["backup"] = value
 
     def model_size(self):
         if self.size > 0:
@@ -55,7 +94,13 @@ class ModelPatcher:
         n.object_patches = self.object_patches.copy()
         n.model_options = copy.deepcopy(self.model_options)
         n.model_keys = self.model_keys
+
+        self.on_cloned(n)
+
         return n
+
+    def on_cloned(self, n):
+        n.patches_hash_info = self.patches_hash_info
 
     def is_clone(self, other):
         if hasattr(other, "model") and self.model is other.model:
@@ -160,7 +205,7 @@ class ModelPatcher:
         if hasattr(self.model, "get_dtype"):
             return self.model.get_dtype()
 
-    def add_patches(self, patches, strength_patch=1.0, strength_model=1.0):
+    def add_patches(self, patches, patch_key, strength_patch=1.0, strength_model=1.0):
         p = set()
         for k in patches:
             if k in self.model_keys:
@@ -168,6 +213,11 @@ class ModelPatcher:
                 current_patches = self.patches.get(k, [])
                 current_patches.append((strength_patch, patches[k], strength_model))
                 self.patches[k] = current_patches
+
+        self.running_patches_hash = rolling_md5(
+            prev_digest=self.running_patches_hash,
+            key=patch_key, a=strength_patch, b=strength_model
+        )
 
         return list(p)
 
@@ -194,7 +244,7 @@ class ModelPatcher:
                     sd.pop(k)
         return sd
 
-    def patch_model(self, device_to=None, patch_weights=True):
+    def patch_model(self, device_to=None, patch_weights=True, allow_persistent_loras=False):
         for k in self.object_patches:
             old = ldm_patched.modules.utils.get_attr(self.model, k)
             if k not in self.object_patches_backup:
@@ -202,29 +252,40 @@ class ModelPatcher:
             ldm_patched.modules.utils.set_attr_raw(self.model, k, self.object_patches[k])
 
         if patch_weights:
-            model_sd = self.model_state_dict()
-            for key in self.patches:
-                if key not in model_sd:
-                    print(f'Could not patch as "{key}" does not exist in model...')
-                    continue
+            do_patch = (
+                (not allow_persistent_loras) or
+                (len(self.patches) > 0 and self.current_patches_hash is None)
+            )
 
-                weight = model_sd[key]
+            if do_patch:
+                backup = self.backup
+                model_sd = self.model_state_dict()
+                
+                for key in self.patches:
+                    if key not in model_sd:
+                        print(f'Could not patch as "{key}" does not exist in model...')
+                        continue
 
-                inplace_update = self.weight_inplace_update
+                    weight = model_sd[key]
 
-                if key not in self.backup:
-                    self.backup[key] = weight.to(device=self.offload_device, copy=inplace_update)
+                    inplace_update = self.weight_inplace_update
 
-                if device_to is not None:
-                    temp_weight = ldm_patched.modules.model_management.cast_to_device(weight, device_to, torch.float32, copy=True)
-                else:
-                    temp_weight = weight.to(torch.float32, copy=True)
-                out_weight = self.calculate_weight(self.patches[key], temp_weight, key).to(weight.dtype)
-                if inplace_update:
-                    ldm_patched.modules.utils.copy_to_param(self.model, key, out_weight)
-                else:
-                    ldm_patched.modules.utils.set_attr(self.model, key, out_weight)
-                del temp_weight
+                    if key not in backup:
+                        backup[key] = weight.to(device=self.offload_device, copy=inplace_update)
+
+                    if device_to is not None:
+                        temp_weight = ldm_patched.modules.model_management.cast_to_device(weight, device_to, torch.float32, copy=True)
+                    else:
+                        temp_weight = weight.to(torch.float32, copy=True)
+                    out_weight = self.calculate_weight(self.patches[key], temp_weight, key).to(weight.dtype)
+                    if inplace_update:
+                        ldm_patched.modules.utils.copy_to_param(self.model, key, out_weight)
+                    else:
+                        ldm_patched.modules.utils.set_attr(self.model, key, out_weight)
+                    del temp_weight
+
+                if len(self.patches) > 0 and self.running_patches_hash is not None:
+                    self.current_patches_hash = self.running_patches_hash
 
             if device_to is not None:
                 self.model.to(device_to)
@@ -402,17 +463,27 @@ class ModelPatcher:
 
         return weight
 
-    def unpatch_model(self, device_to=None):
-        keys = list(self.backup.keys())
+    def unpatch_model(self, device_to=None, allow_persistent_loras=False):
+        backup = self.backup
 
-        if self.weight_inplace_update:
-            for k in keys:
-                ldm_patched.modules.utils.copy_to_param(self.model, k, self.backup[k])
-        else:
-            for k in keys:
-                ldm_patched.modules.utils.set_attr(self.model, k, self.backup[k])
+        do_unpatch = (
+            (not allow_persistent_loras) or 
+            (len(backup) > 0 and self.current_patches_hash is not None and self.running_patches_hash != self.current_patches_hash) or
+            (len(backup) > 0 and self.current_patches_hash is None)
+        )
 
-        self.backup = {}
+        if do_unpatch:
+            keys = list(backup.keys())
+
+            if self.weight_inplace_update:
+                for k in keys:
+                    ldm_patched.modules.utils.copy_to_param(self.model, k, backup[k])
+            else:
+                for k in keys:
+                    ldm_patched.modules.utils.set_attr(self.model, k, backup[k])
+
+            self.backup = {}
+            self.current_patches_hash = None
 
         if device_to is not None:
             self.model.to(device_to)

--- a/ldm_patched/modules/model_patcher.py
+++ b/ldm_patched/modules/model_patcher.py
@@ -8,7 +8,6 @@ import inspect
 import ldm_patched.modules.model_management
 import ldm_patched.modules.utils
 import torch
-import hashlib
 
 extra_weight_calculators = {}
 
@@ -30,35 +29,35 @@ class ModelPatcher:
             self.current_device = current_device
 
         self.weight_inplace_update = weight_inplace_update
-        self.patches_hash_info = {
-            "running_patches_hash": None,
-            "current_patches_hash": None,
+        self.patches_version_info = {
+            "running_patches_version": 0,
+            "current_patches_version": 0,
             "backup": {}
         }
 
     @property
-    def running_patches_hash(self):
-        return self.patches_hash_info["running_patches_hash"]
+    def running_patches_version(self):
+        return self.patches_version_info["running_patches_version"]
 
-    @running_patches_hash.setter
-    def running_patches_hash(self, value):
-        self.patches_hash_info["running_patches_hash"] = value
+    @running_patches_version.setter
+    def running_patches_version(self, value):
+        self.patches_version_info["running_patches_version"] = value
 
     @property
-    def current_patches_hash(self):
-        return self.patches_hash_info["current_patches_hash"]
+    def current_patches_version(self):
+        return self.patches_version_info["current_patches_version"]
 
-    @current_patches_hash.setter
-    def current_patches_hash(self, value):
-        self.patches_hash_info["current_patches_hash"] = value
+    @current_patches_version.setter
+    def current_patches_version(self, value):
+        self.patches_version_info["current_patches_version"] = value
 
     @property
     def backup(self):
-        return self.patches_hash_info["backup"]
+        return self.patches_version_info["backup"]
 
     @backup.setter
     def backup(self, value):
-        self.patches_hash_info["backup"] = value
+        self.patches_version_info["backup"] = value
 
     def model_size(self):
         if self.size > 0:
@@ -90,7 +89,7 @@ class ModelPatcher:
         return n
 
     def on_cloned(self, n):
-        n.patches_hash_info = self.patches_hash_info
+        n.patches_version_info = self.patches_version_info
 
     def is_clone(self, other):
         if hasattr(other, "model") and self.model is other.model:
@@ -195,7 +194,7 @@ class ModelPatcher:
         if hasattr(self.model, "get_dtype"):
             return self.model.get_dtype()
 
-    def add_patches(self, patches, patch_key, strength_patch=1.0, strength_model=1.0):
+    def add_patches(self, patches, strength_patch=1.0, strength_model=1.0):
         p = set()
         for k in patches:
             if k in self.model_keys:
@@ -204,11 +203,7 @@ class ModelPatcher:
                 current_patches.append((strength_patch, patches[k], strength_model))
                 self.patches[k] = current_patches
 
-        h = hashlib.md5()
-        h.update(bytes.fromhex(self.running_patches_hash or "DEADBEEF" * 4))
-        h.update(f"{patch_key}|{strength_patch!r}|{strength_model!r}".encode())
-        self.running_patches_hash = h.hexdigest()
-
+        self.running_patches_version += 1
         return list(p)
 
     def get_key_patches(self, filter_prefix=None):
@@ -244,7 +239,7 @@ class ModelPatcher:
         if patch_weights:
             do_patch = (
                 (not allow_persistent_loras) or
-                (len(self.patches) > 0 and self.current_patches_hash is None)
+                (len(self.patches) > 0 and self.current_patches_version == 0)
             )
 
             if do_patch:
@@ -274,8 +269,8 @@ class ModelPatcher:
                         ldm_patched.modules.utils.set_attr(self.model, key, out_weight)
                     del temp_weight
 
-                if len(self.patches) > 0 and self.running_patches_hash is not None:
-                    self.current_patches_hash = self.running_patches_hash
+                if len(self.patches) > 0 and self.running_patches_version != 0:
+                    self.current_patches_version = self.running_patches_version
 
             if device_to is not None:
                 self.model.to(device_to)
@@ -457,9 +452,8 @@ class ModelPatcher:
         backup = self.backup
 
         do_unpatch = (
-            (not allow_persistent_loras) or 
-            (len(backup) > 0 and self.current_patches_hash is not None and self.running_patches_hash != self.current_patches_hash) or
-            (len(backup) > 0 and self.current_patches_hash is None)
+            (not allow_persistent_loras) or
+            (len(backup) > 0 and self.current_patches_version != self.running_patches_version)
         )
 
         if do_unpatch:
@@ -473,7 +467,7 @@ class ModelPatcher:
                     ldm_patched.modules.utils.set_attr(self.model, k, backup[k])
 
             self.backup = {}
-            self.current_patches_hash = None
+            self.current_patches_version = 0
 
         if device_to is not None:
             self.model.to(device_to)

--- a/ldm_patched/modules/model_patcher.py
+++ b/ldm_patched/modules/model_patcher.py
@@ -9,19 +9,9 @@ import ldm_patched.modules.model_management
 import ldm_patched.modules.utils
 import torch
 import hashlib
-import struct
 
 extra_weight_calculators = {}
 
-
-def rolling_md5(key, a, b, prev_digest):
-    h = hashlib.md5()
-    if prev_digest is None:
-        prev_digest = "DEADBEEF" * 16
-    h.update(bytes.fromhex(prev_digest))
-    h.update(key.encode('utf-8'))
-    h.update(struct.pack('>dd', a, b))
-    return h.hexdigest()
 
 class ModelPatcher:
     def __init__(self, model, load_device, offload_device, size=0, current_device=None, weight_inplace_update=False):
@@ -214,10 +204,10 @@ class ModelPatcher:
                 current_patches.append((strength_patch, patches[k], strength_model))
                 self.patches[k] = current_patches
 
-        self.running_patches_hash = rolling_md5(
-            prev_digest=self.running_patches_hash,
-            key=patch_key, a=strength_patch, b=strength_model
-        )
+        h = hashlib.md5()
+        h.update(bytes.fromhex(self.running_patches_hash or "DEADBEEF" * 16))
+        h.update(f"{patch_key}|{strength_patch!r}|{strength_model!r}".encode())
+        self.running_patches_hash = h.hexdigest()
 
         return list(p)
 

--- a/ldm_patched/modules/model_patcher.py
+++ b/ldm_patched/modules/model_patcher.py
@@ -17,6 +17,7 @@ class ModelPatcher:
         self.size = size
         self.model = model
         self.patches = {}
+        self.backup = {}
         self.object_patches = {}
         self.object_patches_backup = {}
         self.model_options = {"transformer_options": {}}
@@ -29,35 +30,7 @@ class ModelPatcher:
             self.current_device = current_device
 
         self.weight_inplace_update = weight_inplace_update
-        self.patches_version_info = {
-            "running_patches_version": 0,
-            "current_patches_version": 0,
-            "backup": {}
-        }
-
-    @property
-    def running_patches_version(self):
-        return self.patches_version_info["running_patches_version"]
-
-    @running_patches_version.setter
-    def running_patches_version(self, value):
-        self.patches_version_info["running_patches_version"] = value
-
-    @property
-    def current_patches_version(self):
-        return self.patches_version_info["current_patches_version"]
-
-    @current_patches_version.setter
-    def current_patches_version(self, value):
-        self.patches_version_info["current_patches_version"] = value
-
-    @property
-    def backup(self):
-        return self.patches_version_info["backup"]
-
-    @backup.setter
-    def backup(self, value):
-        self.patches_version_info["backup"] = value
+        self.patches_version = { "running": 0, "current": 0 }
 
     def model_size(self):
         if self.size > 0:
@@ -80,16 +53,13 @@ class ModelPatcher:
         for k in self.patches:
             n.patches[k] = self.patches[k][:]
 
+        n.backup = self.backup
         n.object_patches = self.object_patches.copy()
         n.model_options = copy.deepcopy(self.model_options)
         n.model_keys = self.model_keys
-
-        self.on_cloned(n)
+        n.patches_version = self.patches_version
 
         return n
-
-    def on_cloned(self, n):
-        n.patches_version_info = self.patches_version_info
 
     def is_clone(self, other):
         if hasattr(other, "model") and self.model is other.model:
@@ -203,7 +173,7 @@ class ModelPatcher:
                 current_patches.append((strength_patch, patches[k], strength_model))
                 self.patches[k] = current_patches
 
-        self.running_patches_version += 1
+        self.patches_version["running"] += 1
         return list(p)
 
     def get_key_patches(self, filter_prefix=None):
@@ -239,11 +209,10 @@ class ModelPatcher:
         if patch_weights:
             do_patch = (
                 (not allow_persistent_loras) or
-                (len(self.patches) > 0 and self.current_patches_version == 0)
+                (self.patches and self.patches_version["current"] == 0)
             )
 
             if do_patch:
-                backup = self.backup
                 model_sd = self.model_state_dict()
                 
                 for key in self.patches:
@@ -255,8 +224,8 @@ class ModelPatcher:
 
                     inplace_update = self.weight_inplace_update
 
-                    if key not in backup:
-                        backup[key] = weight.to(device=self.offload_device, copy=inplace_update)
+                    if key not in self.backup:
+                        self.backup[key] = weight.to(device=self.offload_device, copy=inplace_update)
 
                     if device_to is not None:
                         temp_weight = ldm_patched.modules.model_management.cast_to_device(weight, device_to, torch.float32, copy=True)
@@ -269,8 +238,8 @@ class ModelPatcher:
                         ldm_patched.modules.utils.set_attr(self.model, key, out_weight)
                     del temp_weight
 
-                if len(self.patches) > 0 and self.running_patches_version != 0:
-                    self.current_patches_version = self.running_patches_version
+                if self.patches and self.patches_version["running"] != 0:
+                    self.patches_version["current"] = self.patches_version["running"]
 
             if device_to is not None:
                 self.model.to(device_to)
@@ -449,25 +418,23 @@ class ModelPatcher:
         return weight
 
     def unpatch_model(self, device_to=None, allow_persistent_loras=False):
-        backup = self.backup
-
         do_unpatch = (
             (not allow_persistent_loras) or
-            (len(backup) > 0 and self.current_patches_version != self.running_patches_version)
+            (self.backup and self.patches_version["current"] != self.patches_version["running"])
         )
 
         if do_unpatch:
-            keys = list(backup.keys())
+            keys = list(self.backup.keys())
 
             if self.weight_inplace_update:
                 for k in keys:
-                    ldm_patched.modules.utils.copy_to_param(self.model, k, backup[k])
+                    ldm_patched.modules.utils.copy_to_param(self.model, k, self.backup[k])
             else:
                 for k in keys:
-                    ldm_patched.modules.utils.set_attr(self.model, k, backup[k])
+                    ldm_patched.modules.utils.set_attr(self.model, k, self.backup[k])
 
-            self.backup = {}
-            self.current_patches_version = 0
+            self.backup.clear()
+            self.patches_version["current"] = 0
 
         if device_to is not None:
             self.model.to(device_to)

--- a/ldm_patched/modules/sd.py
+++ b/ldm_patched/modules/sd.py
@@ -51,7 +51,7 @@ def load_lora_for_models(model, clip, lora, strength_model, strength_clip, filen
     new_clip = clip.clone() if clip is not None else None
 
     if new_model is not None and len(lora_unet) > 0:
-        loaded_keys = new_model.add_patches(lora_unet, strength_model)
+        loaded_keys = new_model.add_patches(lora_unet, f"{filename}-{model_flag}-UNet", strength_model)
         skipped_keys = [item for item in lora_unet if item not in loaded_keys]
         if len(skipped_keys) > 12:
             print(f"[LORA] Mismatch {filename} for {model_flag}-UNet with {len(skipped_keys)} keys mismatched in {len(loaded_keys)} keys")
@@ -60,7 +60,7 @@ def load_lora_for_models(model, clip, lora, strength_model, strength_clip, filen
             model = new_model
 
     if new_clip is not None and len(lora_clip) > 0:
-        loaded_keys = new_clip.add_patches(lora_clip, strength_clip)
+        loaded_keys = new_clip.add_patches(lora_clip, f"{filename}-{model_flag}-CLIP", strength_clip)
         skipped_keys = [item for item in lora_clip if item not in loaded_keys]
         if len(skipped_keys) > 12:
             print(f"[LORA] Mismatch {filename} for {model_flag}-CLIP with {len(skipped_keys)} keys mismatched in {len(loaded_keys)} keys")
@@ -102,8 +102,8 @@ class CLIP:
         n.layer_idx = self.layer_idx
         return n
 
-    def add_patches(self, patches, strength_patch=1.0, strength_model=1.0):
-        return self.patcher.add_patches(patches, strength_patch, strength_model)
+    def add_patches(self, patches, patch_key, strength_patch=1.0, strength_model=1.0):
+        return self.patcher.add_patches(patches, patch_key, strength_patch, strength_model)
 
     def clip_layer(self, layer_idx):
         self.layer_idx = layer_idx

--- a/ldm_patched/modules/sd.py
+++ b/ldm_patched/modules/sd.py
@@ -51,7 +51,7 @@ def load_lora_for_models(model, clip, lora, strength_model, strength_clip, filen
     new_clip = clip.clone() if clip is not None else None
 
     if new_model is not None and len(lora_unet) > 0:
-        loaded_keys = new_model.add_patches(lora_unet, f"{filename}-{model_flag}-UNet", strength_model)
+        loaded_keys = new_model.add_patches(lora_unet, strength_model)
         skipped_keys = [item for item in lora_unet if item not in loaded_keys]
         if len(skipped_keys) > 12:
             print(f"[LORA] Mismatch {filename} for {model_flag}-UNet with {len(skipped_keys)} keys mismatched in {len(loaded_keys)} keys")
@@ -60,7 +60,7 @@ def load_lora_for_models(model, clip, lora, strength_model, strength_clip, filen
             model = new_model
 
     if new_clip is not None and len(lora_clip) > 0:
-        loaded_keys = new_clip.add_patches(lora_clip, f"{filename}-{model_flag}-CLIP", strength_clip)
+        loaded_keys = new_clip.add_patches(lora_clip, strength_clip)
         skipped_keys = [item for item in lora_clip if item not in loaded_keys]
         if len(skipped_keys) > 12:
             print(f"[LORA] Mismatch {filename} for {model_flag}-CLIP with {len(skipped_keys)} keys mismatched in {len(loaded_keys)} keys")
@@ -102,8 +102,8 @@ class CLIP:
         n.layer_idx = self.layer_idx
         return n
 
-    def add_patches(self, patches, patch_key, strength_patch=1.0, strength_model=1.0):
-        return self.patcher.add_patches(patches, patch_key, strength_patch, strength_model)
+    def add_patches(self, patches, strength_patch=1.0, strength_model=1.0):
+        return self.patcher.add_patches(patches, strength_patch, strength_model)
 
     def clip_layer(self, layer_idx):
         self.layer_idx = layer_idx

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -242,6 +242,7 @@ options_templates.update(
             "skip_early_cond": OptionInfo(0.0, "Ignore Negative Prompt during Early Steps", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.05}, infotext="Skip Early CFG").info("in percentage of total steps; 0 = disable; higher = faster"),
             "s_min_uncond": OptionInfo(0.0, "Skip Negative Prompt during Later Steps", gr.Slider, {"minimum": 0.0, "maximum": 8.0, "step": 0.05}).info('in "sigma"; 0 = disable; higher = faster'),
             "persistent_cond_cache": OptionInfo(True, "Persistent Cond Cache").info("do not recalculate conds if the prompts and parameters have not changed since previous generation"),
+            "persistent_patches": OptionInfo(True, "Persistent LoRA Patches").info("skip model patching and unpatching if the model, specified LoRAs or their weights have not changed since previous generation"),
             "div_precision": OptionDiv(),
             "fp8_storage": OptionInfo(False, "Store UNet Weights in fp8").info("store the weights in fp8; inference in fp16; reduce memory usage; reduce speed; reduce quality").needs_restart(),
             "fp8_fast": OptionInfo(False, "Inference UNet in fast fp8 operations").info("inference in fp8 using <b>torch._scaled_mm</b>; increase speed; reduce quality; require <b>RTX 40</b> or newer").needs_restart(),

--- a/modules_forge/unet_patcher.py
+++ b/modules_forge/unet_patcher.py
@@ -26,6 +26,7 @@ class UnetPatcher(ModelPatcher):
         for k in self.patches:
             n.patches[k] = self.patches[k][:]
 
+        n.backup = self.backup
         n.object_patches = self.object_patches.copy()
         n.model_options = copy.deepcopy(self.model_options)
         n.model_keys = self.model_keys
@@ -33,8 +34,7 @@ class UnetPatcher(ModelPatcher):
         n.extra_preserved_memory_during_sampling = self.extra_preserved_memory_during_sampling
         n.extra_model_patchers_during_sampling = self.extra_model_patchers_during_sampling.copy()
         n.extra_concat_condition = self.extra_concat_condition
-
-        super().on_cloned(n)
+        n.patches_version = self.patches_version
 
         return n
 

--- a/modules_forge/unet_patcher.py
+++ b/modules_forge/unet_patcher.py
@@ -33,6 +33,9 @@ class UnetPatcher(ModelPatcher):
         n.extra_preserved_memory_during_sampling = self.extra_preserved_memory_during_sampling
         n.extra_model_patchers_during_sampling = self.extra_model_patchers_during_sampling.copy()
         n.extra_concat_condition = self.extra_concat_condition
+
+        super().on_cloned(n)
+
         return n
 
     def add_extra_preserved_memory_during_sampling(self, memory_in_bytes: int):


### PR DESCRIPTION
Only unpatch and patch models if LoRAs and/or weights have changed.

By default, WebUI is very conservative when it comes to unpatching and patching; patches are removed and readded between generations, even if the weights or LoRA haven't changed. This can be relatively expensive, taking at a minimum 0.5-1 seconds per generation. This time only increases with each additional LoRA, and extra passes (ADetailer, hires and so on).

Essentially, we keep a running hash (based on the LoRA filename and strength) of the patches that have been applied to a model, and only unpatch and repatch if they've changed (or a new model is loaded).

Of note is that we change the behaviour of `ModelPatcher.backup` -- it's now shared among clones so that we can properly unpatch as clones are created and destroyed. I haven't seen any bugs due to having this shared.

I've put an option to enable and disabled under "Optimizations". I guess it could be made a command line, but it feels more appropriate to be an actual toggle.

**Goes without saying, this is fairly experimental and will require more testing -- I've done as much as I can locally and am opening a pull request to get more feedback.**