### PR TITLE
Add --prefer-fp16-upscalers to permit loading of upscaling models for fp16 inference

### DIFF
--- a/ldm_patched/modules/args_parser.py
+++ b/ldm_patched/modules/args_parser.py
@@ -83,7 +83,7 @@ parser.add_argument("--pin-shared-memory", action="store_true")
 
 parser.add_argument("--fast-fp16", action="store_true")
 parser.add_argument("--persistent-patches", action="store_true")
-parser.add_argument("--prefer-fp16-upscalers", action="store_true")
+
 
 class SageAttentionAPIs(enum.Enum):
     Automatic = "auto"

--- a/ldm_patched/modules/args_parser.py
+++ b/ldm_patched/modules/args_parser.py
@@ -83,7 +83,7 @@ parser.add_argument("--pin-shared-memory", action="store_true")
 
 parser.add_argument("--fast-fp16", action="store_true")
 parser.add_argument("--persistent-patches", action="store_true")
-
+parser.add_argument("--prefer-fp16-upscalers", action="store_true")
 
 class SageAttentionAPIs(enum.Enum):
     Automatic = "auto"

--- a/modules/esrgan_model.py
+++ b/modules/esrgan_model.py
@@ -44,7 +44,7 @@ class UpscalerESRGAN(Upscaler):
             scaler_data = UpscalerData(name, file, self, scale)
             self.scalers.append(scaler_data)
 
-    def do_upscale(self, img: Image.Image, selected_model: str, scale: int):
+    def do_upscale(self, img: Image.Image, selected_model: str):
         prepare_free_memory()
         try:
             model = self.load_model(selected_model)
@@ -55,8 +55,7 @@ class UpscalerESRGAN(Upscaler):
             model=model,
             img=img,
             tile_size=opts.ESRGAN_tile,
-            tile_overlap=opts.ESRGAN_tile_overlap,
-            target_scale=scale
+            tile_overlap=opts.ESRGAN_tile_overlap
         )
 
     @lru_cache(maxsize=3, typed=False)

--- a/modules/esrgan_model.py
+++ b/modules/esrgan_model.py
@@ -8,7 +8,11 @@ from modules.shared import opts
 from modules.upscaler import Upscaler, UpscalerData
 from modules.upscaler_utils import upscale_with_model
 from modules_forge.forge_util import prepare_free_memory
+from ldm_patched.modules.args_parser import args
 
+PREFER_HALF = args.prefer_fp16_upscalers
+if PREFER_HALF:
+    print("Prefer Half-Precision Upscalers:", PREFER_HALF)
 
 class UpscalerESRGAN(Upscaler):
     def __init__(self, dirname: str):
@@ -40,7 +44,7 @@ class UpscalerESRGAN(Upscaler):
             scaler_data = UpscalerData(name, file, self, scale)
             self.scalers.append(scaler_data)
 
-    def do_upscale(self, img: Image.Image, selected_model: str):
+    def do_upscale(self, img: Image.Image, selected_model: str, scale: int):
         prepare_free_memory()
         try:
             model = self.load_model(selected_model)
@@ -52,6 +56,7 @@ class UpscalerESRGAN(Upscaler):
             img=img,
             tile_size=opts.ESRGAN_tile,
             tile_overlap=opts.ESRGAN_tile_overlap,
+            target_scale=scale
         )
 
     @lru_cache(maxsize=3, typed=False)
@@ -65,6 +70,6 @@ class UpscalerESRGAN(Upscaler):
                 file_name=path.rsplit("/", 1)[-1],
             )
 
-        model = modelloader.load_spandrel_model(filename, device="cpu")
+        model = modelloader.load_spandrel_model(filename, device="cpu", prefer_half=PREFER_HALF)
         model.to(devices.device_esrgan)
         return model

--- a/modules/esrgan_model.py
+++ b/modules/esrgan_model.py
@@ -8,11 +8,12 @@ from modules.shared import opts
 from modules.upscaler import Upscaler, UpscalerData
 from modules.upscaler_utils import upscale_with_model
 from modules_forge.forge_util import prepare_free_memory
-from ldm_patched.modules.args_parser import args
 
-PREFER_HALF = args.prefer_fp16_upscalers
+
+PREFER_HALF = opts.prefer_fp16_upscalers
 if PREFER_HALF:
-    print("Prefer Half-Precision Upscalers:", PREFER_HALF)
+    print("[Upscalers] Prefer Half-Precision:", PREFER_HALF)
+
 
 class UpscalerESRGAN(Upscaler):
     def __init__(self, dirname: str):
@@ -55,7 +56,7 @@ class UpscalerESRGAN(Upscaler):
             model=model,
             img=img,
             tile_size=opts.ESRGAN_tile,
-            tile_overlap=opts.ESRGAN_tile_overlap
+            tile_overlap=opts.ESRGAN_tile_overlap,
         )
 
     @lru_cache(maxsize=3, typed=False)

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -120,7 +120,7 @@ options_templates.update(
             "ESRGAN_tile_overlap": OptionInfo(16, "Tile Overlap for Upscalers", gr.Slider, {"minimum": 0, "maximum": 64, "step": 4}).info("low values = visible seam"),
             "upscaler_for_img2img": OptionInfo("None", "Upscaler for img2img", gr.Dropdown, lambda: {"choices": [x.name for x in shared.sd_upscalers]}).info("for resizing the input image if the image resolution is smaller than the generation resolution"),
             "upscaling_max_images_in_cache": OptionInfo(4, "Number of upscaled images to cache", gr.Slider, {"minimum": 0, "maximum": 8, "step": 1}),
-            "prefer_fp16_upscalers": OptionInfo(False, "Prefer to load Upscaler in fp16").info("not all upscalers support half precision"),
+            "prefer_fp16_upscalers": OptionInfo(False, "Prefer to load Upscaler in fp16").info("not all upscalers support half precision").needs_restart(),
         },
     )
 )

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -120,6 +120,7 @@ options_templates.update(
             "ESRGAN_tile_overlap": OptionInfo(16, "Tile Overlap for Upscalers", gr.Slider, {"minimum": 0, "maximum": 64, "step": 4}).info("low values = visible seam"),
             "upscaler_for_img2img": OptionInfo("None", "Upscaler for img2img", gr.Dropdown, lambda: {"choices": [x.name for x in shared.sd_upscalers]}).info("for resizing the input image if the image resolution is smaller than the generation resolution"),
             "upscaling_max_images_in_cache": OptionInfo(4, "Number of upscaled images to cache", gr.Slider, {"minimum": 0, "maximum": 8, "step": 1}),
+            "prefer_fp16_upscalers": OptionInfo(False, "Prefer to load Upscaler in fp16").info("not all upscalers support half precision"),
         },
     )
 )


### PR DESCRIPTION
Allow loading of upscaler models for fp16 inference, if supported.

This PR adds a new argument, `--prefer-fp16-upscalers`. All this does is pass `prefer_half=True` to `modelloader.load_spandrel_model`, which in turn will read the model descriptor and attempt to load the upscaler model for fp16 inference. If the model doesn't support it, `load_spandrel_model` prints a message letting the user know, and the model will be loaded at fp32 as usual.

Here are the results for upscaling a 1216x832 image to 2432x1664 (2x) with 4xUltraSharp.

With `--prefer-fp16-upscalers`:
```
tiled upscale: 100%|███████████████████████████████████████████████████████████████████|
20/20 [00:01<00:00, 15.09it/s]
```
Without `--prefer-fp16-upscalers`:
```
tiled upscale: 100%|███████████████████████████████████████████████████████████████████|
20/20 [00:02<00:00,  9.57it/s]
```

As expected, there is a negligible quality loss, nothing I could really notice in practical terms. Given the speed boost, I think giving the user the option is a good compromise.