### PR TITLE
Allow async model moves in model_patcher when --cuda-stream is used and CUDA is available

### DIFF
--- a/ldm_patched/modules/model_management.py
+++ b/ldm_patched/modules/model_management.py
@@ -397,6 +397,7 @@ class LoadedModel:
             )
             real_async_memory = 0
             mem_counter = 0
+            self.real_model = self.model # Force sync if streaming is enabled.
             for m in self.real_model.modules():
                 if hasattr(m, "ldm_patched_cast_weights"):
                     m.prev_ldm_patched_cast_weights = m.ldm_patched_cast_weights
@@ -427,7 +428,7 @@ class LoadedModel:
 
         if is_intel_xpu() and not args.disable_ipex_hijack:
             self.real_model = torch.xpu.optimize(
-                self.real_model.eval(),
+                self.model.eval(), # Force sync if streaming is enabled.
                 inplace=True,
                 auto_kernel_selection=True,
                 graph_mode=True,

--- a/ldm_patched/modules/model_management.py
+++ b/ldm_patched/modules/model_management.py
@@ -397,7 +397,7 @@ class LoadedModel:
             )
             real_async_memory = 0
             mem_counter = 0
-            self.real_model = self.model # Force sync if streaming is enabled.
+            self.real_model = self.model.model # Force sync if streaming is enabled.
             for m in self.real_model.modules():
                 if hasattr(m, "ldm_patched_cast_weights"):
                     m.prev_ldm_patched_cast_weights = m.ldm_patched_cast_weights
@@ -428,7 +428,7 @@ class LoadedModel:
 
         if is_intel_xpu() and not args.disable_ipex_hijack:
             self.real_model = torch.xpu.optimize(
-                self.model.eval(), # Force sync if streaming is enabled.
+                self.model.model.eval(), # Force sync if streaming is enabled.
                 inplace=True,
                 auto_kernel_selection=True,
                 graph_mode=True,

--- a/ldm_patched/modules/model_patcher.py
+++ b/ldm_patched/modules/model_patcher.py
@@ -24,6 +24,7 @@ if PERSISTENT_PATCHES:
 
 CUDA_STREAM = args.cuda_stream and torch.cuda.is_available()
 
+
 class AsyncMover:
     def __init__(self):
         self.backing_stream = None
@@ -34,21 +35,23 @@ class AsyncMover:
             torch.cuda.current_stream().wait_stream(self.backing_stream)
             self.is_streaming = False
 
-    def __call__(self, model, device_to: torch.device):
+    def __call__(self, model: torch.nn.Module, device_to: torch.device):
         if device_to is None:
             return
 
-        if CUDA_STREAM:
-            if self.backing_stream is None:
-                self.backing_stream = torch.cuda.Stream()
-            else:
-                self.wait_for_stream()
-
-            with torch.inference_mode(), torch.cuda.stream(self.backing_stream):
-                model.to(device_to, non_blocking=True)
-                self.is_streaming = True
-        else:
+        if not CUDA_STREAM:
             model.to(device_to)
+            return
+
+        if self.backing_stream is None:
+            self.backing_stream = torch.cuda.Stream()
+        else:
+            self.wait_for_stream()
+
+        with torch.inference_mode(), torch.cuda.stream(self.backing_stream):
+            model.to(device_to, non_blocking=True)
+            self.is_streaming = True
+
 
 class PatchStatus:
     def __init__(self):

--- a/ldm_patched/modules/model_patcher.py
+++ b/ldm_patched/modules/model_patcher.py
@@ -22,6 +22,33 @@ PERSISTENT_PATCHES = args.persistent_patches
 if PERSISTENT_PATCHES:
     print("[Experimental] Persistent Patches:", PERSISTENT_PATCHES)
 
+CUDA_STREAM = args.cuda_stream and torch.cuda.is_available()
+
+class AsyncMover:
+    def __init__(self):
+        self.backing_stream = None
+        self.is_streaming = False
+
+    def wait_for_stream(self):
+        if CUDA_STREAM and self.is_streaming and self.backing_stream is not None:
+            torch.cuda.current_stream().wait_stream(self.backing_stream)
+            self.is_streaming = False
+
+    def __call__(self, model, device_to: torch.device):
+        if device_to is None:
+            return
+
+        if CUDA_STREAM:
+            if self.backing_stream is None:
+                self.backing_stream = torch.cuda.Stream()
+            else:
+                self.wait_for_stream()
+
+            with torch.inference_mode(), torch.cuda.stream(self.backing_stream):
+                model.to(device_to, non_blocking=True)
+                self.is_streaming = True
+        else:
+            model.to(device_to)
 
 class PatchStatus:
     def __init__(self):
@@ -63,25 +90,33 @@ class PatchStatus:
 class ModelPatcher:
     def __init__(self, model, load_device, offload_device, size=0, current_device=None, weight_inplace_update=False):
         self.size = size
-        self.model = model
+        self._model = model
         self.patches = {}
         self.backup = {}
         self.object_patches = {}
         self.object_patches_backup = {}
         self.model_options = {"transformer_options": {}}
-        self.model_size()
         self.load_device = load_device
         self.offload_device = offload_device
         self.current_device = self.offload_device if current_device is None else current_device
         self.weight_inplace_update = weight_inplace_update
 
         self.patch_status = PatchStatus()
+        self.async_mover = AsyncMover()
+
+        self.model_size()
+
+    @property
+    def model(self):
+        self.async_mover.wait_for_stream()
+        return self._model
 
     def model_size(self):
         if self.size > 0:
             return self.size
-        model_sd = self.model.state_dict()
-        self.size = ldm_patched.modules.model_management.module_size(self.model)
+        model = self.model
+        model_sd = model.state_dict()
+        self.size = ldm_patched.modules.model_management.module_size(model)
         self.model_keys = set(model_sd.keys())
         return self.size
 
@@ -103,6 +138,7 @@ class ModelPatcher:
         n.model_options = copy.deepcopy(self.model_options)
         n.model_keys = self.model_keys
         n.patch_status = self.patch_status
+        n.async_mover = self.async_mover
 
         return n
 
@@ -243,14 +279,16 @@ class ModelPatcher:
         return sd
 
     def patch_model(self, device_to=None, patch_weights=True):
+        model = self.model
+
         for k in self.object_patches:
-            old = ldm_patched.modules.utils.get_attr(self.model, k)
+            old = ldm_patched.modules.utils.get_attr(model, k)
             if k not in self.object_patches_backup:
                 self.object_patches_backup[k] = old
-            ldm_patched.modules.utils.set_attr_raw(self.model, k, self.object_patches[k])
+            ldm_patched.modules.utils.set_attr_raw(model, k, self.object_patches[k])
 
         if not patch_weights:
-            return self.model
+            return model
 
         if self.patches and self.patch_status.require_patch():
             model_sd = self.model_state_dict()
@@ -272,18 +310,18 @@ class ModelPatcher:
                     temp_weight = weight.to(torch.float32, copy=True)
                 out_weight = self.calculate_weight(self.patches[key], temp_weight, key).to(weight.dtype)
                 if inplace_update:
-                    ldm_patched.modules.utils.copy_to_param(self.model, key, out_weight)
+                    ldm_patched.modules.utils.copy_to_param(model, key, out_weight)
                 else:
-                    ldm_patched.modules.utils.set_attr(self.model, key, out_weight)
+                    ldm_patched.modules.utils.set_attr(model, key, out_weight)
                 del temp_weight
 
             self.patch_status.patch()
 
         if device_to is not None:
-            self.model.to(device_to)
+            self.async_mover(model, device_to)
             self.current_device = device_to
 
-        return self.model
+        return model
 
     def calculate_weight(self, patches, weight, key):
         for p in patches:
@@ -456,26 +494,28 @@ class ModelPatcher:
         return weight
 
     def unpatch_model(self, device_to=None):
+        model = self.model
+
         if self.backup and self.patch_status.require_unpatch():
             keys = list(self.backup.keys())
 
             if self.weight_inplace_update:
                 for k in keys:
-                    ldm_patched.modules.utils.copy_to_param(self.model, k, self.backup[k])
+                    ldm_patched.modules.utils.copy_to_param(model, k, self.backup[k])
             else:
                 for k in keys:
-                    ldm_patched.modules.utils.set_attr(self.model, k, self.backup[k])
+                    ldm_patched.modules.utils.set_attr(model, k, self.backup[k])
 
             self.backup.clear()
             self.patch_status.unpatch()
 
         if device_to is not None:
-            self.model.to(device_to)
+            self.async_mover(model, device_to)
             self.current_device = device_to
 
         keys = list(self.object_patches_backup.keys())
         for k in keys:
-            ldm_patched.modules.utils.set_attr_raw(self.model, k, self.object_patches_backup[k])
+            ldm_patched.modules.utils.set_attr_raw(model, k, self.object_patches_backup[k])
 
         self.object_patches_backup.clear()
 
@@ -483,4 +523,5 @@ class ModelPatcher:
         del self.patches
         del self.object_patches
         del self.model_options
-        self.model = None
+        self.async_mover = None
+        self._model = None

--- a/ldm_patched/modules/model_patcher.py
+++ b/ldm_patched/modules/model_patcher.py
@@ -38,7 +38,7 @@ class AsyncMover:
         if device_to is None:
             return
 
-        if not stream.using_stream:
+        if not stream.using_stream or not ldm_patched.modules.model_management.device_supports_non_blocking(device_to):
             model.to(device_to)
             return
 

--- a/ldm_patched/modules/model_patcher.py
+++ b/ldm_patched/modules/model_patcher.py
@@ -14,6 +14,7 @@ import torch
 import ldm_patched.modules.model_management
 import ldm_patched.modules.utils
 from ldm_patched.modules.args_parser import args
+from modules_forge import stream
 
 extra_weight_calculators = {}  # backward compatibility
 
@@ -22,8 +23,6 @@ PERSISTENT_PATCHES = args.persistent_patches
 if PERSISTENT_PATCHES:
     print("[Experimental] Persistent Patches:", PERSISTENT_PATCHES)
 
-CUDA_STREAM = args.cuda_stream and torch.cuda.is_available()
-
 
 class AsyncMover:
     def __init__(self):
@@ -31,24 +30,24 @@ class AsyncMover:
         self.is_streaming = False
 
     def wait_for_stream(self):
-        if CUDA_STREAM and self.is_streaming and self.backing_stream is not None:
-            torch.cuda.current_stream().wait_stream(self.backing_stream)
+        if stream.using_stream and self.is_streaming and self.backing_stream is not None:
+            stream.current_stream.wait_stream(self.backing_stream)
             self.is_streaming = False
 
     def __call__(self, model: torch.nn.Module, device_to: torch.device):
         if device_to is None:
             return
 
-        if not CUDA_STREAM:
+        if not stream.using_stream:
             model.to(device_to)
             return
 
         if self.backing_stream is None:
-            self.backing_stream = torch.cuda.Stream()
+            self.backing_stream = stream.get_new_stream()
         else:
             self.wait_for_stream()
 
-        with torch.inference_mode(), torch.cuda.stream(self.backing_stream):
+        with torch.inference_mode(), stream.stream_context()(self.backing_stream):
             model.to(device_to, non_blocking=True)
             self.is_streaming = True
 

--- a/ldm_patched/modules/model_patcher.py
+++ b/ldm_patched/modules/model_patcher.py
@@ -124,7 +124,7 @@ class ModelPatcher:
 
     def clone(self):
         n = ModelPatcher(
-            self.model,
+            self._model,
             self.load_device,
             self.offload_device,
             self.size,
@@ -145,7 +145,7 @@ class ModelPatcher:
         return n
 
     def is_clone(self, other):
-        return getattr(other, "model", None) is self.model
+        return getattr(other, "_model", None) is self._model
 
     def memory_required(self, input_shape):
         return self.model.memory_required(input_shape=input_shape)

--- a/modules_forge/unet_patcher.py
+++ b/modules_forge/unet_patcher.py
@@ -14,7 +14,7 @@ class UnetPatcher(ModelPatcher):
 
     def clone(self):
         n = UnetPatcher(
-            self.model,
+            self._model,
             self.load_device,
             self.offload_device,
             self.size,

--- a/modules_forge/unet_patcher.py
+++ b/modules_forge/unet_patcher.py
@@ -34,6 +34,7 @@ class UnetPatcher(ModelPatcher):
         n.extra_model_patchers_during_sampling = self.extra_model_patchers_during_sampling.copy()
         n.extra_concat_condition = self.extra_concat_condition
         n.patch_status = self.patch_status
+        n.async_mover = self.async_mover
 
         return n
 


### PR DESCRIPTION
Allow non-blocking moves of models in model patcher via CUDA streams, improving performance in low VRAM situations, when model ejection and reloading is high.

With this PR, model `to()` calls in `ModelPatcher` are significantly improved in low VRAM situations, and slightly improved under normal circumstances. To test on my 4090 Mobile (16GB VRAM), I ran an image generation of a 32-step 1216x832 image, 15-step upscaling via 4xUltraSharp by 2x, then an ADetailer pass. This requires several model unloads/loads, mainly the UNet, to allow enough VRAM for VAE encoding/decoding. I did several warmup runs before taking numbers, and added some timing code around the model move itself, just to get additional timings:

```
[MODEL PATCHER] Model move took: 0.093s
Moving model(s) has taken 0.12 seconds
```

The `[MODEL PATCHER]` time reflects the duration of the actual model move, while the `Moving model(s)` line captures the total time for the full move operation (which may include patching, reallocation, etc.).

---

### ✅ With Optimization

| Event | `[MODEL PATCHER]` Move Time | `Moving model(s)` Total Time |
|-------|-----------------------------|-------------------------------|
| 1     | 0.005s                      | 0.02s                        |
| 2     | 0.093s                      | 0.12s                        |
| 3     | 0.090s                      | 0.23s                        |
| 4     | 0.089s                      | 0.10s                        |

- **Average `[MODEL PATCHER]` time:** `0.069s`  
- **Average total move time:** `0.1175s`

---

### ❌ Without Optimization

| Event | `[MODEL PATCHER]` Move Time | `Moving model(s)` Total Time |
|-------|-----------------------------|-------------------------------|
| 1     | 0.006s                      | 0.02s                        |
| 2     | 0.712s                      | 0.74s                        |
| 3     | 0.843s                      | 0.87s                        |
| 4     | 0.569s                      | 0.58s                        |

- **Average `[MODEL PATCHER]` time:** `0.5325s`  
- **Average total move time:** `0.5525s`

---

### 🔍 Summary

| Metric                  | Optimized Avg | Unoptimized Avg | Speedup         |
|------------------------|---------------|------------------|-----------------|
| `[MODEL PATCHER]` Time | 0.069s        | 0.5325s          | **~7.7× faster** |
| Total Move Time        | 0.1175s       | 0.5525s          | **~4.7× faster** |

---

Basically, there is a massive reduction in model move times when it does work; the gains are less significant when there's little to no VRAM pressure (as models don't need to be ejected and reloaded).