### PR TITLE
Add full GPU tile compositing for upscaling

### DIFF
--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -121,6 +121,7 @@ options_templates.update(
             "upscaler_for_img2img": OptionInfo("None", "Upscaler for img2img", gr.Dropdown, lambda: {"choices": [x.name for x in shared.sd_upscalers]}).info("for resizing the input image if the image resolution is smaller than the generation resolution"),
             "upscaling_max_images_in_cache": OptionInfo(4, "Number of upscaled images to cache", gr.Slider, {"minimum": 0, "maximum": 8, "step": 1}),
             "prefer_fp16_upscalers": OptionInfo(False, "Prefer to load Upscaler in fp16").info("not all upscalers support half precision").needs_restart(),
+            "composite_tiles_on_gpu": OptionInfo(False, "Composite tiles on GPU").info("reduces memory usage and improves performance"),
         },
     )
 )

--- a/modules/upscaler_utils.py
+++ b/modules/upscaler_utils.py
@@ -11,6 +11,109 @@ from modules import devices, images, shared, torch_utils
 logger = logging.getLogger(__name__)
 
 
+def pil_rgb_to_tensor_bgr(img: Image.Image, param: torch.Tensor) -> torch.Tensor:
+    tensor = torch.from_numpy(np.asarray(img)).to(param.device)
+    tensor = tensor.to(param.dtype).mul_(1.0 / 255.0).permute(2, 0, 1)
+    return tensor[[2, 1, 0], ...].unsqueeze(0).contiguous()
+
+def tensor_bgr_to_pil_rgb(tensor: torch.Tensor) -> Image.Image:
+    tensor = tensor[:, [2, 1, 0], ...]
+    tensor = tensor.squeeze(0).permute(1, 2, 0).mul_(255.0).round_().clamp_(0.0, 255.0)
+    return Image.fromarray(tensor.to(torch.uint8).cpu().numpy())
+
+def upscale_tensor_tiles(model, tensor: torch.Tensor, tile_size: int, overlap: int, desc: str) -> torch.Tensor:
+    _, _, H_in, W_in = tensor.shape
+    stride = tile_size - overlap
+    n_tiles_x, n_tiles_y = (W_in + stride - 1) // stride, (H_in + stride - 1) // stride
+    total_tiles = n_tiles_x * n_tiles_y
+
+    if tile_size <= 0 or total_tiles <= 4:
+        with torch.inference_mode():
+            return model(tensor)
+
+    device = tensor.device
+    dtype = tensor.dtype # Accumulate in native model dtype.
+
+    accum = None
+    model_scale = None
+    H_out = W_out = None
+
+    last_mask = None
+    last_mask_key = None
+
+    # Generate feathered mask for tile overlap.
+    def get_weight_mask(h, w, y, x):
+        top, bottom, left, right = y > 0, y + h < H_out, x > 0, x + w < W_out
+        key = (h, w, top, bottom, left, right)
+
+        if key == last_mask_key:
+            return key, last_mask
+        elif overlap == 0:
+            mask = torch.ones((1, 1, h, w), device=device, dtype=dtype)
+        else:
+            ov_h, ov_w = min(overlap, h), min(overlap, w)
+
+            ramp_x, ramp_y = torch.ones(w, device=device, dtype=dtype), torch.ones(h, device=device, dtype=dtype)
+            fade_x, fade_y = torch.linspace(0, 1, ov_w, device=device, dtype=dtype), torch.linspace(0, 1, ov_h, device=device, dtype=dtype)
+
+            ramp_x[:ov_w].lerp_(fade_x, float(left))
+            ramp_x[-ov_w:].lerp_(fade_x.flip(0), float(right))
+            ramp_y[:ov_h].lerp_(fade_y, float(top))
+            ramp_y[-ov_h:].lerp_(fade_y.flip(0), float(bottom))
+
+            mask = (ramp_y[:, None] * ramp_x[None, :]).expand(1, 1, h, w)
+        return key, mask
+
+    with torch.inference_mode(), tqdm.tqdm(desc=desc, total=total_tiles) as pbar:
+        for tile_idx in range(total_tiles):
+            if shared.state.interrupted:
+                return None
+
+            # Loop in row-major or column-major, depending on aspect ratio to maximise hit-rate on cached mask.
+            x_idx, y_idx = (
+                (tile_idx % n_tiles_x, tile_idx // n_tiles_x) if W_in >= H_in else 
+                (tile_idx // n_tiles_y, tile_idx % n_tiles_y)
+            )
+            x, y = x_idx * stride, y_idx * stride
+
+            tile = tensor[:, :, y:y + tile_size, x:x + tile_size]
+            out = model(tile)
+
+            if model_scale is None:
+                model_scale = out.shape[-2] / tile.shape[-2]
+                H_out, W_out = int(H_in * model_scale), int(W_in * model_scale)
+                accum = torch.zeros((1, 4, H_out, W_out), dtype=dtype, device=device)
+
+            h_out, w_out = out.shape[-2:]
+            y_out, x_out = int(y * model_scale), int(x * model_scale)
+            ys, ye = y_out, y_out + h_out
+            xs, xe = x_out, x_out + w_out
+
+            # With correct traversal order, mask hit-rate is about 40%.
+            last_mask_key, last_mask = get_weight_mask(h_out, w_out, y_out, x_out)
+            accum_slice = accum[:, :, ys:ye, xs:xe]
+            accum_slice[:, :3].addcmul_(out, last_mask)
+            accum_slice[:, 3:].add_(last_mask)
+
+            del tile, out
+            pbar.update(1)
+
+    del last_mask
+    return accum[:, :3].div_(accum[:, 3:].clamp_min_(1e-6))
+
+def upscale_with_model_gpu(
+    model: Callable[[torch.Tensor], torch.Tensor],
+    img: Image.Image,
+    *,
+    tile_size: int,
+    tile_overlap: int = 0,
+    desc="tiled upscale"
+) -> Image.Image:
+    
+    tensor = pil_rgb_to_tensor_bgr(img, torch_utils.get_param(model))
+    out = upscale_tensor_tiles(model, tensor, tile_size, tile_overlap, desc)
+    return img if out is None else tensor_bgr_to_pil_rgb(out)
+
 def pil_image_to_torch_bgr(img: Image.Image) -> torch.Tensor:
     img = np.array(img.convert("RGB"))
     img = img[:, :, ::-1]  # flip RGB to BGR
@@ -47,7 +150,7 @@ def upscale_pil_patch(model, img: Image.Image) -> Image.Image:
             return torch_bgr_to_pil_image(model(tensor))
 
 
-def upscale_with_model(
+def upscale_with_model_cpu(
     model: Callable[[torch.Tensor], torch.Tensor],
     img: Image.Image,
     *,
@@ -91,6 +194,20 @@ def upscale_with_model(
         overlap=grid.overlap * scale_factor,
     )
     return images.combine_grid(newgrid)
+
+
+def upscale_with_model(
+    model: Callable[[torch.Tensor], torch.Tensor],
+    img: Image.Image,
+    *,
+    tile_size: int,
+    tile_overlap: int = 0,
+    desc="tiled upscale"
+) -> Image.Image:
+    if shared.opts.composite_tiles_on_gpu:
+        return upscale_with_model_gpu(model, img, tile_size=tile_size, tile_overlap=tile_overlap, desc=f"{desc} (GPU composite)")
+    else:
+        return upscale_with_model_cpu(model, img, tile_size=tile_size, tile_overlap=tile_overlap, desc=f"{desc} (CPU composite)")
 
 
 def tiled_upscale_2(

--- a/modules/upscaler_utils.py
+++ b/modules/upscaler_utils.py
@@ -73,11 +73,14 @@ def pil_rgb_to_tensor_bgr(img: Image.Image, param: torch.Tensor) -> torch.Tensor
     tensor = tensor.to(param.dtype).mul_(1.0 / 255.0).permute(2, 0, 1)
     return tensor[[2, 1, 0], ...].unsqueeze(0).contiguous()
 
+
 def tensor_bgr_to_pil_rgb(tensor: torch.Tensor) -> Image.Image:
     tensor = tensor[:, [2, 1, 0], ...]
     tensor = tensor.squeeze(0).permute(1, 2, 0).mul_(255.0).round_().clamp_(0.0, 255.0)
     return Image.fromarray(tensor.to(torch.uint8).cpu().numpy())
 
+
+@torch.inference_mode()
 def upscale_tensor_tiles(model, tensor: torch.Tensor, tile_size: int, overlap: int, desc: str) -> torch.Tensor:
     _, _, H_in, W_in = tensor.shape
     stride = tile_size - overlap
@@ -85,11 +88,10 @@ def upscale_tensor_tiles(model, tensor: torch.Tensor, tile_size: int, overlap: i
     total_tiles = n_tiles_x * n_tiles_y
 
     if tile_size <= 0 or total_tiles <= 4:
-        with torch.inference_mode():
-            return model(tensor)
+        return model(tensor)
 
     device = tensor.device
-    dtype = tensor.dtype # Accumulate in native model dtype.
+    dtype = tensor.dtype  # Accumulate in native model dtype.
 
     accum = None
     model_scale = None
@@ -121,19 +123,16 @@ def upscale_tensor_tiles(model, tensor: torch.Tensor, tile_size: int, overlap: i
             mask = (ramp_y[:, None] * ramp_x[None, :]).expand(1, 1, h, w)
         return key, mask
 
-    with torch.inference_mode(), tqdm.tqdm(desc=desc, total=total_tiles) as pbar:
+    with tqdm.tqdm(desc=desc, total=total_tiles) as pbar:
         for tile_idx in range(total_tiles):
             if shared.state.interrupted:
                 return None
 
             # Loop in row-major or column-major, depending on aspect ratio to maximise hit-rate on cached mask.
-            x_idx, y_idx = (
-                (tile_idx % n_tiles_x, tile_idx // n_tiles_x) if W_in >= H_in else 
-                (tile_idx // n_tiles_y, tile_idx % n_tiles_y)
-            )
+            x_idx, y_idx = (tile_idx % n_tiles_x, tile_idx // n_tiles_x) if W_in >= H_in else (tile_idx // n_tiles_y, tile_idx % n_tiles_y)
             x, y = x_idx * stride, y_idx * stride
 
-            tile = tensor[:, :, y:y + tile_size, x:x + tile_size]
+            tile = tensor[:, :, y : y + tile_size, x : x + tile_size]
             out = model(tile)
 
             if model_scale is None:
@@ -158,15 +157,16 @@ def upscale_tensor_tiles(model, tensor: torch.Tensor, tile_size: int, overlap: i
     del last_mask
     return accum[:, :3].div_(accum[:, 3:].clamp_min_(1e-6))
 
+
 def upscale_with_model_gpu(
     model: Callable[[torch.Tensor], torch.Tensor],
     img: Image.Image,
     *,
     tile_size: int,
     tile_overlap: int = 0,
-    desc="tiled upscale"
+    desc="tiled upscale",
 ) -> Image.Image:
-    
+
     tensor = pil_rgb_to_tensor_bgr(img, torch_utils.get_param(model))
     out = upscale_tensor_tiles(model, tensor, tile_size, tile_overlap, desc)
     return img if out is None else tensor_bgr_to_pil_rgb(out)
@@ -260,7 +260,7 @@ def upscale_with_model(
     *,
     tile_size: int,
     tile_overlap: int = 0,
-    desc="tiled upscale"
+    desc="tiled upscale",
 ) -> Image.Image:
     if shared.opts.composite_tiles_on_gpu:
         return upscale_with_model_gpu(model, img, tile_size=tile_size, tile_overlap=tile_overlap, desc=f"{desc} (GPU composite)")


### PR DESCRIPTION
Perform all compositing of upscaled tiles on the GPU, only sending the finished image tensor to the CPU once complete.

The current implementation of tiled upscaling performs a lot of back and forth between PIL, Torch and Numpy, with all the associated data conversions and device transfers. It's somewhat wasteful, when we could perform the compositing directly on GPU, and only pass the result back to the CPU when we're done. It might have been an attempt to control VRAM usage, but ultimately, the CPU-centric approach is worse.

This pull request implements GPU compositing, which can be toggled via the "Composite tiles on GPU" option under "Upscaling". Rather than pass the data round to various APIs, we convert the image directly to a tensor, send it to the GPU, do all upscaling and compositing in Torch, then send it back.

All numbers are based on a 2x upscale of a 1216 x 832 image with fp16 upscalers enabled.

| Metric               | CPU compositing | GPU compositing | Better |
|----------------------|-----------|-----------|--------|
| Iterations/s | 10.35   | 14.85   | ✅ GPU (1.43x faster) |
| Cumulative CUDA Allocated  | 97.03 GB (total) | 80.80 GB (total)  | ✅ GPU  |
| Memory Freed (churn) | 168.77 GB | 141.08 GB | ✅ GPU  |

I've made it an option, as there are minor unavoidable differences in the output, but quality is essentially the same. One thing that could be changed is to accumulate the tiles in float32, regardless of whether the upscaler is running in fp16 or fp32 mode, but I've defaulted to using the upscaler dtype.



