### PR TITLE
Optimised forward pass patch for Spandrel ResidualDenseBlock

### DIFF
--- a/modules/upscaler_utils.py
+++ b/modules/upscaler_utils.py
@@ -10,6 +10,52 @@ from modules import devices, images, shared, torch_utils
 
 logger = logging.getLogger(__name__)
 
+def try_apply_spandrel_patches():
+    try:
+        from spandrel.architectures.__arch_helpers.block import ResidualDenseBlock_5C, RRDB
+
+        _orig_init = ResidualDenseBlock_5C.__init__
+
+        def ResidualDenseBlock_5C_init(self, *args, **kwargs):
+            _orig_init(self, *args, **kwargs)
+            self.nf, self.gc = kwargs.get('nf', 64), kwargs.get('gc', 32)
+
+        def ResidualDenseBlock_5C_forward(self, x):
+            B, _, H, W = x.shape
+            nf, gc = self.nf, self.gc
+
+            buf = torch.empty((B, nf + 4 * gc, H, W), dtype=x.dtype, device=x.device)
+            buf[:, :nf].copy_(x)
+
+            x1 = self.conv1(x)
+            buf[:, nf:nf+gc].copy_(x1)
+
+            x2 = self.conv2(buf[:, :nf+gc])
+            if self.conv1x1: x2.add_(self.conv1x1(x))
+            buf[:, nf+gc:nf+2*gc].copy_(x2)
+
+            x3 = self.conv3(buf[:, :nf+2*gc])
+            buf[:, nf+2*gc:nf+3*gc].copy_(x3)
+
+            x4 = self.conv4(buf[:, :nf+3*gc])
+            if self.conv1x1: x4.add_(x2)
+            buf[:, nf+3*gc:nf+4*gc].copy_(x4)
+
+            x5 = self.conv5(buf)
+            return x5.mul_(0.2).add_(x)
+
+        def RRDB_forward(self, x):
+            return self.RDB3(self.RDB2(self.RDB1(x))).mul_(0.2).add_(x)
+
+        ResidualDenseBlock_5C.__init__ = ResidualDenseBlock_5C_init
+        ResidualDenseBlock_5C.forward = ResidualDenseBlock_5C_forward
+        RRDB.forward = RRDB_forward
+
+        print("[Upscalers] Patched Spandrel blocks with optimized forward passes")
+    except Exception as e:
+        print(f"[Upscalers] Failed to patch Spandrel blocks: {type(e).__name__}: {e}")
+
+try_apply_spandrel_patches()
 
 def pil_image_to_torch_bgr(img: Image.Image) -> torch.Tensor:
     img = np.array(img.convert("RGB"))


### PR DESCRIPTION
Patch the forward passes of Spandrel's `ResidualDenseBlock_5C` and `RRDB` to improve upscaler performance and significantly reduce peak CUDA allocations.

After spending some time looking at the traces during upscaling, [I came across this madness in `block.py`](https://github.com/chaiNNer-org/spandrel/blob/464165cf9cbdfcf39472b7bfe11becf27b40e7b2/libs/spandrel/spandrel/architectures/__arch_helpers/block.py#L437-L448):
```
    def forward(self, x):
        x1 = self.conv1(x)
        x2 = self.conv2(torch.cat((x, x1), 1))
        if self.conv1x1:
            # pylint: disable=not-callable
            x2 = x2 + self.conv1x1(x)  # +
        x3 = self.conv3(torch.cat((x, x1, x2), 1))
        x4 = self.conv4(torch.cat((x, x1, x2, x3), 1))
        if self.conv1x1:
            x4 = x4 + x2  # +
        x5 = self.conv5(torch.cat((x, x1, x2, x3, x4), 1))
        return x5 * 0.2 + x
```
This can be easily rewritten to allocate a single empty tensor, and then just copying the convolutions into that tensor and using in-place ops where we can. I wasn't sure the practical impact this would have, turns out it's quite significant. Statistics were taken with a 2x upscale of a 1216 x 832 image with fp16 upscalers disabled.

| Metric                      | Without patch | With patch        | Better                         |
|-----------------------------|----------------------|----------------------|--------------------------------|
| Iterations/s                | 6.76                 | 8.14                 | ✅ Patch (1.20x faster) |
| Cumulative CUDA Allocated   | 334.79 GB (total)    | 148.06 GB (total)    | ✅ Patch               |

We also patch the forward pass of `RRDB` for a minor benefit. It's much less impactful, but probably still worth doing.

Ultimately this should probably be an upstream patch on Spandrel itself, but given the fix is easy enough to apply ourselves, I've put together this monkey-patch to reap the benefits now.

EDIT: Oh, I should also add this has no impact on quality -- visual results are identical.