### PR TITLE
Fixes for CFG++ samplers

### DIFF
--- a/modules/sd_samplers_cfg_denoiser.py
+++ b/modules/sd_samplers_cfg_denoiser.py
@@ -1,3 +1,4 @@
+import math
 import torch
 from modules import prompt_parser, sd_samplers_common
 from modules.script_callbacks import (
@@ -157,7 +158,8 @@ class CFGDenoiser(torch.nn.Module):
         if 0.0 <= sigma[0] <= s_min_uncond:
             cond_scale = 1.0
 
-        skip_uncond: bool = abs(cond_scale - 1.0) < 10**-6
+        model_options = kwargs.get("model_options", None)
+        skip_uncond: bool = math.isclose(cond_scale, 1.0) and not (model_options or {}).get('disable_cfg1_optimization', False)
         self.padded_cond_uncond = not skip_uncond
 
         denoised = forge_sampler.forge_sample(
@@ -166,7 +168,7 @@ class CFGDenoiser(torch.nn.Module):
             cond_scale=cond_scale,
             cond_composition=cond_composition,
             skip_uncond=skip_uncond,
-            options=kwargs.get("model_options", None),
+            options=model_options,
         )
 
         # if getattr(self.p.sd_model, "cond_stage_key", None) == "edit" and getattr(self, "image_cfg_scale", 1.0) != 1.0:

--- a/modules/sd_samplers_cfg_denoiser.py
+++ b/modules/sd_samplers_cfg_denoiser.py
@@ -1,12 +1,7 @@
 import math
 import torch
 from modules import prompt_parser, sd_samplers_common
-from modules.script_callbacks import (
-    AfterCFGCallbackParams,
-    CFGDenoiserParams,
-    cfg_after_cfg_callback,
-    cfg_denoiser_callback,
-)
+from modules.script_callbacks import AfterCFGCallbackParams, CFGDenoiserParams, cfg_after_cfg_callback, cfg_denoiser_callback
 from modules.shared import opts, state
 from modules_forge import forge_sampler
 
@@ -159,7 +154,7 @@ class CFGDenoiser(torch.nn.Module):
             cond_scale = 1.0
 
         model_options = kwargs.get("model_options", None)
-        skip_uncond: bool = math.isclose(cond_scale, 1.0) and not (model_options or {}).get('disable_cfg1_optimization', False)
+        skip_uncond: bool = math.isclose(cond_scale, 1.0) and not (model_options or {}).get("disable_cfg1_optimization", False)
         self.padded_cond_uncond = not skip_uncond
 
         denoised = forge_sampler.forge_sample(

--- a/modules/sd_samplers_cfgpp.py
+++ b/modules/sd_samplers_cfgpp.py
@@ -1,10 +1,5 @@
 import torch
-from k_diffusion.sampling import (
-    BrownianTreeNoiseSampler,
-    default_noise_sampler,
-    get_ancestral_step,
-    to_d,
-)
+from k_diffusion.sampling import BrownianTreeNoiseSampler, default_noise_sampler, get_ancestral_step, to_d
 from tqdm.auto import trange
 
 
@@ -192,12 +187,14 @@ def sample_dpmpp_2m_cfg_pp(model, x, sigmas, extra_args=None, callback=None, dis
         old_uncond_denoised = uncond_denoised
     return x
 
+
 @torch.no_grad()
 def sample_dpmpp_2m_sde_cfg_pp(model, x, sigmas, extra_args=None, callback=None, disable=None, eta=1.0, s_noise=1.0, noise_sampler=None, solver_type="midpoint"):
-    """DPM-Solver++(2M) SDE"""
+    if len(sigmas) <= 1:
+        return x
 
     if solver_type not in {"heun", "midpoint"}:
-        raise ValueError("solver_type must be 'heun' or 'midpoint'")
+        raise ValueError('solver_type must be "heun" or "midpoint"')
 
     seed = extra_args.get("seed", None)
     sigma_min, sigma_max = sigmas[sigmas > 0].min(), sigmas.max()
@@ -244,6 +241,7 @@ def sample_dpmpp_2m_sde_cfg_pp(model, x, sigmas, extra_args=None, callback=None,
         old_denoised = denoised
         h_last = h
     return x
+
 
 @torch.no_grad()
 def sample_dpmpp_3m_sde_cfg_pp(model, x, sigmas, extra_args=None, callback=None, disable=None, eta=1.0, s_noise=1.0, noise_sampler=None):

--- a/modules/sd_samplers_cfgpp.py
+++ b/modules/sd_samplers_cfgpp.py
@@ -192,12 +192,61 @@ def sample_dpmpp_2m_cfg_pp(model, x, sigmas, extra_args=None, callback=None, dis
         old_uncond_denoised = uncond_denoised
     return x
 
+@torch.no_grad()
+def sample_dpmpp_2m_sde_cfg_pp(model, x, sigmas, extra_args=None, callback=None, disable=None, eta=1.0, s_noise=1.0, noise_sampler=None, solver_type="midpoint"):
+    """DPM-Solver++(2M) SDE"""
+
+    if solver_type not in {"heun", "midpoint"}:
+        raise ValueError("solver_type must be 'heun' or 'midpoint'")
+
+    seed = extra_args.get("seed", None)
+    sigma_min, sigma_max = sigmas[sigmas > 0].min(), sigmas.max()
+    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=seed, cpu=True) if noise_sampler is None else noise_sampler
+    extra_args = {} if extra_args is None else extra_args
+    s_in = x.new_ones([x.shape[0]])
+
+    old_denoised = None
+    h_last = None
+    h = None
+
+    temp = [0]
+
+    def post_cfg_function(args):
+        temp[0] = args["uncond_denoised"]
+        return args["denoised"]
+
+    model_options = extra_args.get("model_options", {}).copy()
+    extra_args["model_options"] = _set_model_options_post_cfg_function(model_options, post_cfg_function, disable_cfg1_optimization=True)
+
+    for i in trange(len(sigmas) - 1, disable=disable):
+        denoised = model(x, sigmas[i] * s_in, **extra_args)
+        if callback is not None:
+            callback({"x": x, "i": i, "sigma": sigmas[i], "sigma_hat": sigmas[i], "denoised": denoised})
+        if sigmas[i + 1] == 0:
+            x = denoised
+        else:
+            t, s = -sigmas[i].log(), -sigmas[i + 1].log()
+            h = s - t
+            eta_h = eta * h
+
+            x = sigmas[i + 1] / sigmas[i] * (-eta_h).exp() * (x + (denoised - temp[0])) + (-h - eta_h).expm1().neg() * denoised
+
+            if old_denoised is not None:
+                r = h_last / h
+                if solver_type == "heun":
+                    x = x + ((-h - eta_h).expm1().neg() / (-h - eta_h) + 1) * (1 / r) * (denoised - old_denoised)
+                elif solver_type == "midpoint":
+                    x = x + 0.5 * (-h - eta_h).expm1().neg() * (1 / r) * (denoised - old_denoised)
+
+            if eta:
+                x = x + noise_sampler(sigmas[i], sigmas[i + 1]) * sigmas[i + 1] * (-2 * eta_h).expm1().neg().sqrt() * s_noise
+
+        old_denoised = denoised
+        h_last = h
+    return x
 
 @torch.no_grad()
-def sample_dpmpp_3m_sde_cfg_pp(model, x, sigmas, extra_args=None, callback=None, disable=None, eta=None, s_noise=None, noise_sampler=None):
-    eta = 1.0 if eta is None else eta
-    s_noise = 1.0 if s_noise is None else s_noise
-
+def sample_dpmpp_3m_sde_cfg_pp(model, x, sigmas, extra_args=None, callback=None, disable=None, eta=1.0, s_noise=1.0, noise_sampler=None):
     if len(sigmas) <= 1:
         return x
 

--- a/modules_forge/forge_alter_samplers.py
+++ b/modules_forge/forge_alter_samplers.py
@@ -26,18 +26,25 @@ class AlterSampler(sd_samplers_kdiffusion.KDiffusionSampler):
             logging.warning("Low CFG is recommended when using CFG++ samplers")
         return super().sample_img2img(p, *args, **kwargs)
 
-
-def build_constructor(sampler_name):
+def build_constructor(sampler_key):
     def constructor(model):
-        return AlterSampler(model, sampler_name)
-
+        return AlterSampler(model, sampler_key)
     return constructor
 
+def create_cfg_pp_sampler(sampler_name, sampler_key):
+    config = {}
+    base_name = sampler_name.removesuffix(" CFG++")
+    for name, _, _, params in sd_samplers_kdiffusion.samplers_k_diffusion:
+        if name == base_name:
+            config = params.copy()
+            break
+
+    return sd_samplers_common.SamplerData(sampler_name, build_constructor(sampler_key=sampler_key), [sampler_key], config)
 
 samplers_data_alter = [
-    sd_samplers_common.SamplerData("DPM++ 2M CFG++", build_constructor(sampler_name="dpmpp_2m_cfg_pp"), ["dpmpp_2m_cfg_pp"], {}),
-    sd_samplers_common.SamplerData("DPM++ SDE CFG++", build_constructor(sampler_name="dpmpp_sde_cfg_pp"), ["dpmpp_sde_cfg_pp"], {}),
-    sd_samplers_common.SamplerData("DPM++ 3M SDE CFG++", build_constructor(sampler_name="dpmpp_3m_sde_cfg_pp"), ["dpmpp_3m_sde_cfg_pp"], {}),
-    sd_samplers_common.SamplerData("Euler a CFG++", build_constructor(sampler_name="euler_ancestral_cfg_pp"), ["euler_ancestral_cfg_pp"], {}),
-    sd_samplers_common.SamplerData("Euler CFG++", build_constructor(sampler_name="euler_cfg_pp"), ["euler_cfg_pp"], {}),
+    create_cfg_pp_sampler("DPM++ 2M CFG++", "dpmpp_2m_cfg_pp"),
+    create_cfg_pp_sampler("DPM++ SDE CFG++", "dpmpp_sde_cfg_pp"),
+    create_cfg_pp_sampler("DPM++ 3M SDE CFG++", "dpmpp_3m_sde_cfg_pp"),
+    create_cfg_pp_sampler("Euler a CFG++", "euler_ancestral_cfg_pp"),
+    create_cfg_pp_sampler("Euler CFG++", "euler_cfg_pp"),
 ]

--- a/modules_forge/forge_alter_samplers.py
+++ b/modules_forge/forge_alter_samplers.py
@@ -44,6 +44,7 @@ def create_cfg_pp_sampler(sampler_name, sampler_key):
 samplers_data_alter = [
     create_cfg_pp_sampler("DPM++ 2M CFG++", "dpmpp_2m_cfg_pp"),
     create_cfg_pp_sampler("DPM++ SDE CFG++", "dpmpp_sde_cfg_pp"),
+    create_cfg_pp_sampler("DPM++ 2M SDE CFG++", "dpmpp_2m_sde_cfg_pp"),
     create_cfg_pp_sampler("DPM++ 3M SDE CFG++", "dpmpp_3m_sde_cfg_pp"),
     create_cfg_pp_sampler("Euler a CFG++", "euler_ancestral_cfg_pp"),
     create_cfg_pp_sampler("Euler CFG++", "euler_cfg_pp"),

--- a/modules_forge/forge_alter_samplers.py
+++ b/modules_forge/forge_alter_samplers.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Callable
 
 from modules import sd_samplers_cfgpp, sd_samplers_common, sd_samplers_kdiffusion
 
@@ -8,30 +9,31 @@ class AlterSampler(sd_samplers_kdiffusion.KDiffusionSampler):
         self.sampler_name = sampler_name
         self.scheduler_name = scheduler_name
         self.unet = sd_model.forge_objects.unet
-        sampler_function = getattr(sd_samplers_cfgpp, f"sample_{self.sampler_name}", None)
+        sampler_function: Callable = getattr(sd_samplers_cfgpp, f"sample_{self.sampler_name}", None)
         if sampler_function is None:
             raise ValueError(f"Unknown sampler: {sampler_name}")
 
         super().__init__(sampler_function, sd_model, None)
 
     def sample(self, p, *args, **kwargs):
-        # self.scheduler_name = p.scheduler
         if p.cfg_scale > 2.0:
-            logging.warning("Low CFG is recommended when using CFG++ samplers")
+            logging.warning("CFG between 1.0 ~ 2.0 is recommended when using CFG++ samplers")
         return super().sample(p, *args, **kwargs)
 
     def sample_img2img(self, p, *args, **kwargs):
-        # self.scheduler_name = p.scheduler
         if p.cfg_scale > 2.0:
-            logging.warning("Low CFG is recommended when using CFG++ samplers")
+            logging.warning("CFG between 1.0 ~ 2.0 is recommended when using CFG++ samplers")
         return super().sample_img2img(p, *args, **kwargs)
 
-def build_constructor(sampler_key):
+
+def build_constructor(sampler_key: str) -> Callable:
     def constructor(model):
         return AlterSampler(model, sampler_key)
+
     return constructor
 
-def create_cfg_pp_sampler(sampler_name, sampler_key):
+
+def create_cfg_pp_sampler(sampler_name: str, sampler_key: str) -> "sd_samplers_common.SamplerData":
     config = {}
     base_name = sampler_name.removesuffix(" CFG++")
     for name, _, _, params in sd_samplers_kdiffusion.samplers_k_diffusion:
@@ -40,6 +42,7 @@ def create_cfg_pp_sampler(sampler_name, sampler_key):
             break
 
     return sd_samplers_common.SamplerData(sampler_name, build_constructor(sampler_key=sampler_key), [sampler_key], config)
+
 
 samplers_data_alter = [
     create_cfg_pp_sampler("DPM++ 2M CFG++", "dpmpp_2m_cfg_pp"),


### PR DESCRIPTION
Not much to this one, basically:

1. CFG = 1 was not being handled correctly in `sd_samplers_cfg_denoiser.py` if `model_options` has `disable_cfg1_optimization` set to `True` (which all CFG++ samplers do), so make sure that's respected.
2. Copy `SamplerData` options for each CFG++ sampler from it's non-CFG counterpart. Makes sure stuff like `second_order` and `discard_next_to_last_sigma` defaults are used.
3. Add DPM++ 2M SDE CFG++, as it's noticeably absent.