### PR TITLE
Support loading upscalers in bf16 when prefer fp16 upscalers is enabled and the upscaler does not support fp16

### DIFF
--- a/modules/modelloader.py
+++ b/modules/modelloader.py
@@ -129,6 +129,9 @@ def load_spandrel_model(
         if model_descriptor.supports_half:
             model_descriptor.model.half()
             half = True
+        elif model_descriptor.supports_bfloat16:
+            model_descriptor.model.bfloat16()
+            half = True
         else:
             logger.warning(f"Model {path} does not support half precision...")
 

--- a/modules/upscaler_utils.py
+++ b/modules/upscaler_utils.py
@@ -67,6 +67,20 @@ def try_patch_spandrel():
 
 try_patch_spandrel()
 
+def call_model(model: Callable[[torch.Tensor], torch.Tensor], x: torch.Tensor) -> torch.Tensor:
+    # Spandrel does not correctly handle non-FP32 for ATD and DAT models.
+    if x.dtype != torch.float32 and model.architecture.name in ['ATD', 'DAT']:
+        try:
+            # Force the upscaler to use the dtype it should for new tensors.
+            torch.set_default_dtype(x.dtype)
+            # Using torch.device incurs a small amount of overhead, but makes sure we don't
+            # get errors when unsupported dtype tensors would be made on the CPU.
+            with torch.device(x.device):
+                return model(x)
+        finally:
+            torch.set_default_dtype(torch.float32)
+    else:
+        return model(x)
 
 def pil_image_to_torch_bgr(img: Image.Image) -> torch.Tensor:
     img = np.array(img.convert("RGB"))
@@ -101,7 +115,7 @@ def upscale_pil_patch(model, img: Image.Image) -> Image.Image:
         tensor = pil_image_to_torch_bgr(img).unsqueeze(0)  # add batch dimension
         tensor = tensor.to(device=param.device, dtype=param.dtype)
         with devices.without_autocast():
-            return torch_bgr_to_pil_image(model(tensor))
+            return torch_bgr_to_pil_image(call_model(model, tensor))
 
 
 def upscale_with_model(
@@ -172,7 +186,7 @@ def tiled_upscale_2(
 
     if tile_size <= 0:
         logger.debug("Upscaling %s without tiling", img.shape)
-        return model(img)
+        return call_model(model, img)
 
     stride = tile_size - tile_overlap
     h_idx_list = list(range(0, h - tile_size, stride)) + [h - tile_size]
@@ -207,7 +221,7 @@ def tiled_upscale_2(
                     w_idx : w_idx + tile_size,
                 ].to(device=device)
 
-                out_patch = model(in_patch)
+                out_patch = call_model(model, in_patch)
 
                 result[
                     ...,


### PR DESCRIPTION
So Spandrel can also load models in `bfloat16` if the [model says it supports it](https://github.com/chaiNNer-org/spandrel/blob/464165cf9cbdfcf39472b7bfe11becf27b40e7b2/libs/spandrel/spandrel/__helpers/model_descriptor.py#L157), unfortunately, calling `model_descriptor.model.bfloat16()` is not enough from some architectures, due to mishandling of dtypes within Spandrel itself.

Good news is this only affects ATD and DAT (PLKSR/RealPLKSR work fine, have not tested others), and we can handle it ourselves by wrapping the model call and forcing the device/dtype.

It's a bit hacky, and there are options to patch the problematic methods within Spandrel itself for each architecture, but this is much cleaner. Also completely compatible with https://github.com/Haoming02/sd-webui-forge-classic/pull/81, will just require using the the wrapped call instead.