### PR TITLE
Use tiled versions of Conv2d and upsampling for VAE decoding

### DIFF
--- a/ldm_patched/ldm/modules/diffusionmodules/model.py
+++ b/ldm_patched/ldm/modules/diffusionmodules/model.py
@@ -524,7 +524,7 @@ class Decoder(nn.Module):
 
         # end
         self.norm_out = Normalize(block_in)
-        self.conv_out = ops.Conv2d(
+        self.conv_out = conv_out_op(
             block_in, out_ch, kernel_size=3, stride=1, padding=1
         )
 

--- a/ldm_patched/ldm/modules/diffusionmodules/model.py
+++ b/ldm_patched/ldm/modules/diffusionmodules/model.py
@@ -14,7 +14,10 @@ import torch.nn as nn
 from ldm_patched.modules import model_management
 from modules.shared import opts
 
-ops = ldm_patched.modules.ops.disable_weight_init
+if opts.sd_vae_tiled_ops:
+    ops = ldm_patched.modules.ops.tiled_ops
+else:
+    ops = ldm_patched.modules.ops.disable_weight_init
 
 if model_management.xformers_enabled_vae():
     import xformers
@@ -58,16 +61,12 @@ class Upsample(nn.Module):
         super().__init__()
         self.with_conv = with_conv
         if self.with_conv:
-            self.conv = ops.Conv2dTiled(
+            self.conv = ops.Conv2d(
                 in_channels, in_channels, kernel_size=3, stride=1, padding=1
             )
 
     def forward(self, x):
         try:
-            # Tiled upsample calls conv2d per tile.
-            if opts.sd_vae_tiled_ops:
-                return ops.tiled_upsample(x, self.conv if self.with_conv else None)
-
             x = torch.nn.functional.interpolate(x, scale_factor=2.0, mode="nearest")
         except:  # operation not implemented for bf16
             b, c, h, w = x.shape
@@ -126,19 +125,19 @@ class ResnetBlock(nn.Module):
 
         self.swish = torch.nn.SiLU(inplace=True)
         self.norm1 = Normalize(in_channels)
-        self.conv1 = ops.Conv2dTiled(
+        self.conv1 = ops.Conv2d(
             in_channels, out_channels, kernel_size=3, stride=1, padding=1
         )
         if temb_channels > 0:
             self.temb_proj = ops.Linear(temb_channels, out_channels)
         self.norm2 = Normalize(out_channels)
         self.dropout = torch.nn.Dropout(dropout, inplace=True)
-        self.conv2 = ops.Conv2dTiled(
+        self.conv2 = ops.Conv2d(
             out_channels, out_channels, kernel_size=3, stride=1, padding=1
         )
         if self.in_channels != self.out_channels:
             if self.use_conv_shortcut:
-                self.conv_shortcut = ops.Conv2dTiled(
+                self.conv_shortcut = ops.Conv2d(
                     in_channels, out_channels, kernel_size=3, stride=1, padding=1
                 )
             else:
@@ -344,7 +343,7 @@ class Encoder(nn.Module):
         self.in_channels = in_channels
 
         # downsampling
-        self.conv_in = ops.Conv2dTiled(
+        self.conv_in = ops.Conv2d(
             in_channels, self.ch, kernel_size=3, stride=1, padding=1
         )
 
@@ -516,13 +515,16 @@ class Decoder(nn.Module):
             up.block = block
             up.attn = attn
             if i_level != 0:
-                up.upsample = Upsample(block_in, resamp_with_conv)
+                if opts.sd_vae_tiled_ops:
+                    up.upsample = ops.Upsample(block_in, resamp_with_conv)
+                else:
+                    up.upsample = Upsample(block_in, resamp_with_conv)
                 curr_res = curr_res * 2
             self.up.insert(0, up)  # prepend to get consistent order
 
         # end
         self.norm_out = Normalize(block_in)
-        self.conv_out = ops.Conv2dTiled(
+        self.conv_out = ops.Conv2d(
             block_in, out_ch, kernel_size=3, stride=1, padding=1
         )
 

--- a/ldm_patched/ldm/modules/diffusionmodules/model.py
+++ b/ldm_patched/ldm/modules/diffusionmodules/model.py
@@ -12,6 +12,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 from ldm_patched.modules import model_management
+from modules.shared import opts
 
 ops = ldm_patched.modules.ops.disable_weight_init
 
@@ -57,12 +58,16 @@ class Upsample(nn.Module):
         super().__init__()
         self.with_conv = with_conv
         if self.with_conv:
-            self.conv = ops.Conv2d(
+            self.conv = ops.Conv2dTiled(
                 in_channels, in_channels, kernel_size=3, stride=1, padding=1
             )
 
     def forward(self, x):
         try:
+            # Tiled upsample calls conv2d per tile.
+            if opts.sd_vae_tiled_ops:
+                return ops.tiled_upsample(x, self.conv if self.with_conv else None)
+
             x = torch.nn.functional.interpolate(x, scale_factor=2.0, mode="nearest")
         except:  # operation not implemented for bf16
             b, c, h, w = x.shape
@@ -121,19 +126,19 @@ class ResnetBlock(nn.Module):
 
         self.swish = torch.nn.SiLU(inplace=True)
         self.norm1 = Normalize(in_channels)
-        self.conv1 = ops.Conv2d(
+        self.conv1 = ops.Conv2dTiled(
             in_channels, out_channels, kernel_size=3, stride=1, padding=1
         )
         if temb_channels > 0:
             self.temb_proj = ops.Linear(temb_channels, out_channels)
         self.norm2 = Normalize(out_channels)
         self.dropout = torch.nn.Dropout(dropout, inplace=True)
-        self.conv2 = ops.Conv2d(
+        self.conv2 = ops.Conv2dTiled(
             out_channels, out_channels, kernel_size=3, stride=1, padding=1
         )
         if self.in_channels != self.out_channels:
             if self.use_conv_shortcut:
-                self.conv_shortcut = ops.Conv2d(
+                self.conv_shortcut = ops.Conv2dTiled(
                     in_channels, out_channels, kernel_size=3, stride=1, padding=1
                 )
             else:
@@ -339,7 +344,7 @@ class Encoder(nn.Module):
         self.in_channels = in_channels
 
         # downsampling
-        self.conv_in = ops.Conv2d(
+        self.conv_in = ops.Conv2dTiled(
             in_channels, self.ch, kernel_size=3, stride=1, padding=1
         )
 
@@ -517,7 +522,7 @@ class Decoder(nn.Module):
 
         # end
         self.norm_out = Normalize(block_in)
-        self.conv_out = conv_out_op(
+        self.conv_out = ops.Conv2dTiled(
             block_in, out_ch, kernel_size=3, stride=1, padding=1
         )
 

--- a/ldm_patched/modules/ops.py
+++ b/ldm_patched/modules/ops.py
@@ -306,7 +306,7 @@ class tiled_ops(disable_weight_init):
             from modules.shared import opts
 
             super().__init__(*arg, **kwargs)
-            self._3x1x1: bool = kwargs.get("kernel_size", 1) == 3 and kwargs.get("stride", 1) == 1 and kwargs.get("padding", 0) == 1
+            self._3x1x1: bool = self.kernel_size == (3, 3) and self.stride == (1, 1) and self.padding == (1, 1)
             self.tile_size = opts.sd_vae_tiled_size
 
         @torch.inference_mode()

--- a/ldm_patched/modules/ops.py
+++ b/ldm_patched/modules/ops.py
@@ -304,7 +304,7 @@ class tiled_ops(disable_weight_init):
 
         def __init__(self, *arg, **kwargs):
             super().__init__(*arg, **kwargs)
-            self._3x1x1 = self.kernel_size == 3 and self.stride == 1 and self.padding == 1
+            self._3x1x1: bool = kwargs["kernel_size"] == 3 and kwargs["stride"] == 1 and kwargs["padding"] == 1
 
         @torch.inference_mode()
         def forward(self, x: torch.Tensor):
@@ -346,7 +346,7 @@ class tiled_ops(disable_weight_init):
             super().__init__()
             self.with_conv = with_conv
             if self.with_conv:
-                self.conv = disable_weight_init.Conv2d(in_channels, in_channels, kernel_size=3, stride=1, padding=1)
+                self.conv = tiled_ops.Conv2d(in_channels, in_channels, kernel_size=3, stride=1, padding=1)
 
         @torch.inference_mode()
         def forward(self, x: torch.Tensor):

--- a/ldm_patched/modules/ops.py
+++ b/ldm_patched/modules/ops.py
@@ -9,9 +9,8 @@ https://github.com/comfyanonymous/ComfyUI
 import contextlib
 
 import torch
-from ldm_patched.modules.model_management import cast_to_device
+from ldm_patched.modules.model_management import cast_to_device, device_supports_non_blocking
 from modules_forge import stream
-from typing import Callable, Tuple
 
 stash = {}
 
@@ -127,13 +126,6 @@ class disable_weight_init:
             else:
                 return super().forward(*args, **kwargs)
 
-    class Conv2dTiled(Conv2d):
-        def forward(self, input: torch.Tensor, enable_tiling: bool = True, **kwargs) -> torch.Tensor:
-            from modules.shared import opts
-            if enable_tiling and opts.sd_vae_tiled_ops:
-                return tiled_conv2d_3x1x1(input, super().forward, self.out_channels, **kwargs)
-            return super().forward(input)
-
     class Conv3d(torch.nn.Conv3d):
         ldm_patched_cast_weights = False
 
@@ -209,9 +201,6 @@ class manual_cast(disable_weight_init):
     class Conv2d(disable_weight_init.Conv2d):
         ldm_patched_cast_weights = True
 
-    class Conv2dTiled(disable_weight_init.Conv2dTiled):
-        ldm_patched_cast_weights = True
-
     class Conv3d(disable_weight_init.Conv3d):
         ldm_patched_cast_weights = True
 
@@ -274,77 +263,6 @@ def fp8_linear(self, input):
     else:
         return o.view((-1, input_shape[1], self.weight.shape[0]))
 
-def tiled_conv2d_3x1x1(x: torch.Tensor, conv: Callable[[torch.Tensor], torch.Tensor], out_channels: int = None, tile_size: int = 128, **kwargs) -> torch.Tensor:
-    B, C, H, W = x.shape
-
-    if H <= tile_size and W <= tile_size:
-        return conv(x, **kwargs)
-
-    out = torch.empty((B, C if out_channels is None else out_channels, H, W), device=x.device, dtype=x.dtype, memory_format=torch.contiguous_format)
-    non_blocking = x.device.type != 'cpu'
-
-    for i in range(0, H, tile_size):
-        for j in range(0, W, tile_size):
-            i0 = max(i - 1, 0)
-            j0 = max(j - 1, 0)
-            i1 = min(i + tile_size + 1, H)
-            j1 = min(j + tile_size + 1, W)
-
-            tile = x[:, :, i0:i1, j0:j1]
-            tile_conv = conv(tile, **kwargs)
-
-            pi = (i - i0)
-            pj = (j - j0)
-            ph = min(tile_size, H - i)
-            pw = min(tile_size, W - j)
-
-            out[:, :, i:i + ph, j:j + pw].copy_(tile_conv[:, :, pi:pi + ph, pj:pj + pw], non_blocking=non_blocking)
-            del tile_conv
-    return out
-
-def tiled_upsample(x: torch.Tensor, conv: Callable[[torch.Tensor], torch.Tensor] = None, size: Tuple[int, int] = None, tile_size: int = 128) -> torch.Tensor:
-    B, C, H, W = x.shape
-    out_H, out_W = (H * 2, W * 2) if size is None else size
-    with_conv = conv is not None
-
-    if out_H <= tile_size and out_W <= tile_size:
-        x_up = torch.nn.functional.interpolate(x, size=(out_H, out_W), mode='nearest')
-        return x_up if with_conv else conv(x_up, enable_tiling=False)
-
-    scale_h = out_H / H
-    scale_w = out_W / W
-
-    out = torch.empty((B, C, out_H, out_W), device=x.device, dtype=x.dtype, memory_format=torch.contiguous_format)
-    non_blocking = x.device.type != 'cpu'
-
-    for i in range(0, H, tile_size):
-        for j in range(0, W, tile_size):
-            i0 = max(i - 1, 0)
-            j0 = max(j - 1, 0)
-            i1 = min(i + tile_size + 1, H)
-            j1 = min(j + tile_size + 1, W)
-            tile = x[:, :, i0:i1, j0:j1]
-
-            tile_up = torch.nn.functional.interpolate(tile, scale_factor=(scale_h, scale_w), mode='nearest')
-
-            if with_conv:
-                tile_up = conv(tile_up, enable_tiling=False)
-
-            pi = int((i - i0) * scale_h)
-            pj = int((j - j0) * scale_w)
-            ph = int(min(tile_size, H - i) * scale_h)
-            pw = int(min(tile_size, W - j) * scale_w)
-
-            oi = int(i * scale_h)
-            oj = int(j * scale_w)
-
-            # Clip output patch to not exceed requested output size
-            ph = min(ph, out_H - oi)
-            pw = min(pw, out_W - oj)
-
-            out[:, :, oi:oi + ph, oj:oj + pw].copy_(tile_up[:, :, pi:pi + ph, pj:pj + pw], non_blocking=non_blocking)
-            del tile_up
-    return out
 
 class fp8_ops(manual_cast):
     class Linear(manual_cast.Linear):
@@ -378,3 +296,99 @@ else:
 
             def forward(self, *args, **kwargs):
                 return super().forward(*args, **kwargs)
+
+
+class tiled_ops(disable_weight_init):
+    class Conv2d(disable_weight_init.Conv2d):
+        tile_size = 128
+
+        def __init__(self, *arg, **kwargs):
+            super().__init__(*arg, **kwargs)
+            self._3x1x1 = self.kernel_size == 3 and self.stride == 1 and self.padding == 1
+
+        @torch.inference_mode()
+        def forward(self, x: torch.Tensor):
+            if not self._3x1x1:
+                return super().forward(x)
+
+            B, C, H, W = x.shape
+
+            if H <= self.tile_size and W <= self.tile_size:
+                return super().forward(x)
+
+            out = torch.empty((B, C if self.out_channels is None else self.out_channels, H, W), device=x.device, dtype=x.dtype, memory_format=torch.contiguous_format)
+            non_blocking = device_supports_non_blocking(x.device)
+
+            for i in range(0, H, self.tile_size):
+                for j in range(0, W, self.tile_size):
+                    i0 = max(i - 1, 0)
+                    j0 = max(j - 1, 0)
+                    i1 = min(i + self.tile_size + 1, H)
+                    j1 = min(j + self.tile_size + 1, W)
+
+                    tile = x[:, :, i0:i1, j0:j1]
+                    tile_conv = super().forward(tile)
+
+                    pi = i - i0
+                    pj = j - j0
+                    ph = min(self.tile_size, H - i)
+                    pw = min(self.tile_size, W - j)
+
+                    out[:, :, i : i + ph, j : j + pw].copy_(tile_conv[:, :, pi : pi + ph, pj : pj + pw], non_blocking=non_blocking)
+                    del tile_conv
+
+            return out
+
+    class Upsample(torch.nn.Module):
+        tile_size: int = 128
+
+        def __init__(self, in_channels, with_conv):
+            super().__init__()
+            self.with_conv = with_conv
+            if self.with_conv:
+                self.conv = disable_weight_init.Conv2d(in_channels, in_channels, kernel_size=3, stride=1, padding=1)
+
+        @torch.inference_mode()
+        def forward(self, x: torch.Tensor):
+            B, C, H, W = x.shape
+            out_H, out_W = (H * 2, W * 2)
+
+            if out_H <= self.tile_size and out_W <= self.tile_size:
+                x_up = torch.nn.functional.interpolate(x, size=(out_H, out_W), mode="nearest")
+                return x_up if not self.with_conv else self.conv(x_up)
+
+            scale_h = out_H / H
+            scale_w = out_W / W
+
+            out = torch.empty((B, C, out_H, out_W), device=x.device, dtype=x.dtype, memory_format=torch.contiguous_format)
+            non_blocking = device_supports_non_blocking(x.device)
+
+            for i in range(0, H, self.tile_size):
+                for j in range(0, W, self.tile_size):
+                    i0 = max(i - 1, 0)
+                    j0 = max(j - 1, 0)
+                    i1 = min(i + self.tile_size + 1, H)
+                    j1 = min(j + self.tile_size + 1, W)
+                    tile = x[:, :, i0:i1, j0:j1]
+
+                    tile_up = torch.nn.functional.interpolate(tile, scale_factor=(scale_h, scale_w), mode="nearest")
+
+                    if self.with_conv:
+                        tile_up = self.conv(tile_up)
+
+                    pi = int((i - i0) * scale_h)
+                    pj = int((j - j0) * scale_w)
+                    ph = int(min(self.tile_size, H - i) * scale_h)
+                    pw = int(min(self.tile_size, W - j) * scale_w)
+
+                    oi = int(i * scale_h)
+                    oj = int(j * scale_w)
+
+                    # Clip output patch to not exceed requested output size
+                    ph = min(ph, out_H - oi)
+                    pw = min(pw, out_W - oj)
+
+                    out[:, :, oi : oi + ph, oj : oj + pw].copy_(tile_up[:, :, pi : pi + ph, pj : pj + pw], non_blocking=non_blocking)
+                    del tile_up
+
+            return out

--- a/ldm_patched/modules/ops.py
+++ b/ldm_patched/modules/ops.py
@@ -11,6 +11,7 @@ import contextlib
 import torch
 from ldm_patched.modules.model_management import cast_to_device
 from modules_forge import stream
+from typing import Callable, Tuple
 
 stash = {}
 
@@ -126,6 +127,13 @@ class disable_weight_init:
             else:
                 return super().forward(*args, **kwargs)
 
+    class Conv2dTiled(Conv2d):
+        def forward(self, input: torch.Tensor, enable_tiling: bool = True, **kwargs) -> torch.Tensor:
+            from modules.shared import opts
+            if enable_tiling and opts.sd_vae_tiled_ops:
+                return tiled_conv2d_3x1x1(input, super().forward, self.out_channels, **kwargs)
+            return super().forward(input)
+
     class Conv3d(torch.nn.Conv3d):
         ldm_patched_cast_weights = False
 
@@ -201,6 +209,9 @@ class manual_cast(disable_weight_init):
     class Conv2d(disable_weight_init.Conv2d):
         ldm_patched_cast_weights = True
 
+    class Conv2dTiled(disable_weight_init.Conv2dTiled):
+        ldm_patched_cast_weights = True
+
     class Conv3d(disable_weight_init.Conv3d):
         ldm_patched_cast_weights = True
 
@@ -263,6 +274,77 @@ def fp8_linear(self, input):
     else:
         return o.view((-1, input_shape[1], self.weight.shape[0]))
 
+def tiled_conv2d_3x1x1(x: torch.Tensor, conv: Callable[[torch.Tensor], torch.Tensor], out_channels: int = None, tile_size: int = 128, **kwargs) -> torch.Tensor:
+    B, C, H, W = x.shape
+
+    if H <= tile_size and W <= tile_size:
+        return conv(x, **kwargs)
+
+    out = torch.empty((B, C if out_channels is None else out_channels, H, W), device=x.device, dtype=x.dtype, memory_format=torch.contiguous_format)
+    non_blocking = x.device.type != 'cpu'
+
+    for i in range(0, H, tile_size):
+        for j in range(0, W, tile_size):
+            i0 = max(i - 1, 0)
+            j0 = max(j - 1, 0)
+            i1 = min(i + tile_size + 1, H)
+            j1 = min(j + tile_size + 1, W)
+
+            tile = x[:, :, i0:i1, j0:j1]
+            tile_conv = conv(tile, **kwargs)
+
+            pi = (i - i0)
+            pj = (j - j0)
+            ph = min(tile_size, H - i)
+            pw = min(tile_size, W - j)
+
+            out[:, :, i:i + ph, j:j + pw].copy_(tile_conv[:, :, pi:pi + ph, pj:pj + pw], non_blocking=non_blocking)
+            del tile_conv
+    return out
+
+def tiled_upsample(x: torch.Tensor, conv: Callable[[torch.Tensor], torch.Tensor] = None, size: Tuple[int, int] = None, tile_size: int = 128) -> torch.Tensor:
+    B, C, H, W = x.shape
+    out_H, out_W = (H * 2, W * 2) if size is None else size
+    with_conv = conv is not None
+
+    if out_H <= tile_size and out_W <= tile_size:
+        x_up = torch.nn.functional.interpolate(x, size=(out_H, out_W), mode='nearest')
+        return x_up if with_conv else conv(x_up, enable_tiling=False)
+
+    scale_h = out_H / H
+    scale_w = out_W / W
+
+    out = torch.empty((B, C, out_H, out_W), device=x.device, dtype=x.dtype, memory_format=torch.contiguous_format)
+    non_blocking = x.device.type != 'cpu'
+
+    for i in range(0, H, tile_size):
+        for j in range(0, W, tile_size):
+            i0 = max(i - 1, 0)
+            j0 = max(j - 1, 0)
+            i1 = min(i + tile_size + 1, H)
+            j1 = min(j + tile_size + 1, W)
+            tile = x[:, :, i0:i1, j0:j1]
+
+            tile_up = torch.nn.functional.interpolate(tile, scale_factor=(scale_h, scale_w), mode='nearest')
+
+            if with_conv:
+                tile_up = conv(tile_up, enable_tiling=False)
+
+            pi = int((i - i0) * scale_h)
+            pj = int((j - j0) * scale_w)
+            ph = int(min(tile_size, H - i) * scale_h)
+            pw = int(min(tile_size, W - j) * scale_w)
+
+            oi = int(i * scale_h)
+            oj = int(j * scale_w)
+
+            # Clip output patch to not exceed requested output size
+            ph = min(ph, out_H - oi)
+            pw = min(pw, out_W - oj)
+
+            out[:, :, oi:oi + ph, oj:oj + pw].copy_(tile_up[:, :, pi:pi + ph, pj:pj + pw], non_blocking=non_blocking)
+            del tile_up
+    return out
 
 class fp8_ops(manual_cast):
     class Linear(manual_cast.Linear):

--- a/ldm_patched/modules/ops.py
+++ b/ldm_patched/modules/ops.py
@@ -300,11 +300,14 @@ else:
 
 class tiled_ops(disable_weight_init):
     class Conv2d(disable_weight_init.Conv2d):
-        tile_size = 128
+        tile_size: int
 
         def __init__(self, *arg, **kwargs):
+            from modules.shared import opts
+
             super().__init__(*arg, **kwargs)
-            self._3x1x1: bool = kwargs["kernel_size"] == 3 and kwargs["stride"] == 1 and kwargs["padding"] == 1
+            self._3x1x1: bool = kwargs.get("kernel_size", 1) == 3 and kwargs.get("stride", 1) == 1 and kwargs.get("padding", 0) == 1
+            self.tile_size = opts.sd_vae_tiled_size
 
         @torch.inference_mode()
         def forward(self, x: torch.Tensor):
@@ -340,13 +343,17 @@ class tiled_ops(disable_weight_init):
             return out
 
     class Upsample(torch.nn.Module):
-        tile_size: int = 128
+        tile_size: int
 
         def __init__(self, in_channels, with_conv):
+            from modules.shared import opts
+
             super().__init__()
             self.with_conv = with_conv
             if self.with_conv:
                 self.conv = tiled_ops.Conv2d(in_channels, in_channels, kernel_size=3, stride=1, padding=1)
+
+            self.tile_size = opts.sd_vae_tiled_size
 
         @torch.inference_mode()
         def forward(self, x: torch.Tensor):

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -207,9 +207,11 @@ to create the resulting image after the sampling is finished. For img2img, VAE i
             "sd_vae": OptionInfo("Automatic", "SD VAE", gr.Dropdown, lambda: {"choices": shared_items.sd_vae_items()}, refresh=shared_items.refresh_vae_list, infotext="VAE").info("None = always use VAE from checkpoint; Automatic = use VAE with the same filename as checkpoint"),
             "sd_vae_overrides_per_model_preferences": OptionInfo(True, '"SD VAE" option overrides per-model preference'),
             "prefer_vae_precision_float16": OptionInfo(False, "Prefer VAE in float16 precision").info("VAE at fp16 tends to cause NaNs; <b>enable with caution!</b>"),
-            "sd_vae_tiled_ops": OptionInfo(False, "Use tiled operations for VAE").info("replace interpolate and Conv2D ops with tiled variants; reduce memory usage").needs_restart(),
             "sd_vae_encode_method": OptionInfo("Full", "VAE for Encoding", gr.Radio, {"choices": ("Full", "TAESD")}, infotext="VAE Encoder").info("method to encode image to latent (img2img / Hires. fix / inpaint)"),
             "sd_vae_decode_method": OptionInfo("Full", "VAE for Decoding", gr.Radio, {"choices": ("Full", "TAESD")}, infotext="VAE Decoder").info("method to decode latent to image"),
+            "tile_exp_div": OptionDiv(),
+            "sd_vae_tiled_ops": OptionInfo(False, "Enable tiling optimizations for VAE").info("replace <b>interpolate</b> and <b>Conv2D</b> ops with tiled variants; reduce memory usage; <i>slightly</i> reduce speed").needs_restart(),
+            "sd_vae_tiled_size": OptionInfo(128, "Tile Size", gr.Slider, {"minimum": 64, "maximum": 256, "step": 64}).info("for the above setting").needs_restart(),
         },
     )
 )

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -207,6 +207,7 @@ to create the resulting image after the sampling is finished. For img2img, VAE i
             "sd_vae": OptionInfo("Automatic", "SD VAE", gr.Dropdown, lambda: {"choices": shared_items.sd_vae_items()}, refresh=shared_items.refresh_vae_list, infotext="VAE").info("None = always use VAE from checkpoint; Automatic = use VAE with the same filename as checkpoint"),
             "sd_vae_overrides_per_model_preferences": OptionInfo(True, '"SD VAE" option overrides per-model preference'),
             "prefer_vae_precision_float16": OptionInfo(False, "Prefer VAE in float16 precision").info("VAE at fp16 tends to cause NaNs; <b>enable with caution!</b>"),
+            "sd_vae_tiled_ops": OptionInfo(False, "Use tiled operations for VAE").info("Replace interpolate and Conv2D ops for VAE with tiled versions, reduces memory usage with similar performance"),
             "sd_vae_encode_method": OptionInfo("Full", "VAE for Encoding", gr.Radio, {"choices": ("Full", "TAESD")}, infotext="VAE Encoder").info("method to encode image to latent (img2img / Hires. fix / inpaint)"),
             "sd_vae_decode_method": OptionInfo("Full", "VAE for Decoding", gr.Radio, {"choices": ("Full", "TAESD")}, infotext="VAE Decoder").info("method to decode latent to image"),
         },

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -207,7 +207,7 @@ to create the resulting image after the sampling is finished. For img2img, VAE i
             "sd_vae": OptionInfo("Automatic", "SD VAE", gr.Dropdown, lambda: {"choices": shared_items.sd_vae_items()}, refresh=shared_items.refresh_vae_list, infotext="VAE").info("None = always use VAE from checkpoint; Automatic = use VAE with the same filename as checkpoint"),
             "sd_vae_overrides_per_model_preferences": OptionInfo(True, '"SD VAE" option overrides per-model preference'),
             "prefer_vae_precision_float16": OptionInfo(False, "Prefer VAE in float16 precision").info("VAE at fp16 tends to cause NaNs; <b>enable with caution!</b>"),
-            "sd_vae_tiled_ops": OptionInfo(False, "Use tiled operations for VAE").info("Replace interpolate and Conv2D ops for VAE with tiled versions, reduces memory usage with similar performance"),
+            "sd_vae_tiled_ops": OptionInfo(False, "Use tiled operations for VAE").info("replace interpolate and Conv2D ops with tiled variants; reduce memory usage").needs_restart(),
             "sd_vae_encode_method": OptionInfo("Full", "VAE for Encoding", gr.Radio, {"choices": ("Full", "TAESD")}, infotext="VAE Encoder").info("method to encode image to latent (img2img / Hires. fix / inpaint)"),
             "sd_vae_decode_method": OptionInfo("Full", "VAE for Decoding", gr.Radio, {"choices": ("Full", "TAESD")}, infotext="VAE Decoder").info("method to decode latent to image"),
         },


### PR DESCRIPTION
Tiled VAE decoding via Never OOM is pretty invaluable when it comes to low VRAM systems, just at a significant cost of speed. However, we can get most of the benefits by targeting the VRAM heavy ops directly -- upsampling and convolutions.

This pull request adds tiled versions of 2x nearest upsampling and Conv2d, though the latter is fixed for 3x1x1 -- basically the core convolution done by VAE decoding. With these optimisations, we get most of the benefits of full-on tiled VAE decoding, but with none of the slowdown.

For comparison, here are benchmarks for a 1152 x 896 image, 32 steps, latent upscaled by 2x with 5 hires steps (I usually use 15). I did a few warmup runs for both before taking numbers.

Without tiled ops:
```
Time taken: 13.5 sec.
A: 8.98 GB, R: 12.48 GB, Sys: 14.2/15.9922 GB (88.8%)
```
With tiled ops:
```
Time taken: 13.5 sec.
A: 6.67 GB, R: 7.80 GB, Sys: 9.2/15.9922 GB (57.4%)
```
Output is also visually identical as far as I can tell. 

Questions are what the optimal tile size is (values between 128-256 are best, though you could make it user-tweakable), as well as how the implementation is done. I ended up making it an op, but you could just plug the methods directly into `ldm_patched\ldm\modules\diffusionmodules\model.py` as that's the only place they're used.

I've gated the tiling ops behind "Use tiled operations for VAE" under the VAE settings.