### PR TITLE
Persistent Patches fix - unpatch prior to patching if needed

### DIFF
--- a/extensions-builtin/Lora/networks.py
+++ b/extensions-builtin/Lora/networks.py
@@ -1,7 +1,7 @@
 import os.path
 import re
 
-from ldm_patched.modules.sd import load_lora_for_models
+from ldm_patched.modules.sd import load_lora_for_models, unpatch_models_prior_to_patch
 from ldm_patched.modules.utils import load_torch_file
 from modules import errors, scripts, sd_models, shared
 
@@ -57,6 +57,10 @@ def load_networks(names, te_multipliers=None, unet_multipliers=None, dyn_dims=No
 
     if current_sd.current_lora_hash == compiled_lora_targets_hash:
         return
+
+    if current_sd.current_lora_hash != str([]):
+        # patch for persistent patches only: need to unpatch prior to patching if lora hash has changed.
+        unpatch_models_prior_to_patch(current_sd.forge_objects.unet, current_sd.forge_objects.clip)
 
     current_sd.current_lora_hash = compiled_lora_targets_hash
     current_sd.forge_objects.unet = current_sd.forge_objects_original.unet

--- a/ldm_patched/modules/model_patcher.py
+++ b/ldm_patched/modules/model_patcher.py
@@ -37,7 +37,10 @@ class PatchStatus:
 
         return self.current == 0
 
-    def require_unpatch(self) -> bool:
+    def require_unpatch(self, is_prepatch=False) -> bool:
+        if is_prepatch:
+            return self.require_prepatch_unpatch()
+
         if not PERSISTENT_PATCHES:
             return True
 
@@ -45,6 +48,15 @@ class PatchStatus:
             return True
 
         return self.current != self.updated
+
+    def require_prepatch_unpatch(self) -> bool:
+        if not PERSISTENT_PATCHES:
+            return False
+
+        if not PatchStatus.has_lora():
+            return False
+
+        return True
 
     def patch(self):
         if self.updated > 0:
@@ -463,8 +475,8 @@ class ModelPatcher:
 
         return weight
 
-    def unpatch_model(self, device_to=None):
-        if self.backup and self.patch_status.require_unpatch():
+    def unpatch_model(self, device_to=None, is_prepatch=False):
+        if self.backup and (self.patch_status.require_unpatch(is_prepatch)):
             keys = list(self.backup.keys())
 
             if self.weight_inplace_update:

--- a/ldm_patched/modules/sd.py
+++ b/ldm_patched/modules/sd.py
@@ -69,6 +69,10 @@ def load_lora_for_models(model, clip, lora, strength_model, strength_clip, filen
 
     return model, clip
 
+def unpatch_models_prior_to_patch(model, clip):
+    model.unpatch_model(model.offload_device, is_prepatch=True)
+    clip.patcher.unpatch_model(clip.patcher.offload_device, is_prepatch=True)
+
 
 class CLIP:
     def __init__(self, target=None, embedding_directory=None, no_init=False):


### PR DESCRIPTION
Steps to reproduce bug this PR is (theoretically) fixing (issue link: https://github.com/Haoming02/sd-webui-forge-classic/issues/117):

1. Start Forge Classic with --persistent-patches feature flag turned on
2. Load a model, add a prompt containing usage of at least one Lora
3. Set a non-random Seed for easier observation
4. Hit "Generate"
5. Significantly alter a Lora weight in the prompt (this makes it easier to check for changes to the image)
6. Hit "Generate"
7. [BUG] Observe the utter lack of change in the image
8. PRESUMED CAUSE: the persistent patches feature (correctly) prevented an unpatch after the first Generate, so the updated Lora weights aren't correctly patched in
9. Hit "Generate" again (no changes to prompt/loras!)
10. Observe the image change correctly according to the Lora weight alteration in step 5.

Persistent Patches is pretty much THE reason I switched to using Forge Classic, but I noticed that I had to hit Generate an extra time each time I fiddled with Lora weights.  This bugged me enough to submit a PR with a proposed fix.

Thanks!

NOTE: I'm not a Python dev at all, so please let me know if any changes are preferred to the proposed implementation (or, if you don't wanna wait on me, I won't be offended if you fix the PR up how you like prior to inclusion, assuming you want to merge this :) )