### PR TITLE
Proposed lora loading optimizations

### DIFF
--- a/extensions-builtin/Lora/networks.py
+++ b/extensions-builtin/Lora/networks.py
@@ -1,6 +1,7 @@
 import os.path
 import re
 
+from ldm_patched.modules.lora import model_lora_keys_clip, model_lora_keys_unet
 from ldm_patched.modules.sd import load_lora_for_models
 from ldm_patched.modules.utils import load_torch_file
 from modules import errors, scripts, sd_models, shared
@@ -58,9 +59,26 @@ def load_networks(names, te_multipliers=None, unet_multipliers=None, dyn_dims=No
     if current_sd.current_lora_hash == compiled_lora_targets_hash:
         return
 
+    # Potential performance enhancement: referential lora load
+    #   - Maintain a list of keys that loras have modified during load process.
+    #       - When loading each subsequent lora, check those keys first, and only iterate the full set of keys in model if
+    #         the lora is touching keys that are not present in the accumulated list of "known" keys.
+    #   - seems to only be a performance boost if there are >1 loras in use
+    #
+    #   - To potentially optimize this further, one could consider keeping the loaded unet/clip keys and accumulated known
+    #     keys in memory until the SD 1.5/SDXL model itself is swapped out by the user.  I didn't go that far (yet), though.
+    do_referential_load = len(compiled_lora_targets) > 1
+
     current_sd.current_lora_hash = compiled_lora_targets_hash
+
     current_sd.forge_objects.unet = current_sd.forge_objects_original.unet
     current_sd.forge_objects.clip = current_sd.forge_objects_original.clip
+
+    unet_keys = model_lora_keys_unet(current_sd.forge_objects.unet.model) if current_sd.forge_objects.unet is not None else {}
+    clip_keys = model_lora_keys_clip(current_sd.forge_objects.clip.cond_stage_model) if current_sd.forge_objects.clip is not None else {}
+
+    accum_unet = set()
+    accum_clip = set()
 
     for filename, strength_model, strength_clip in compiled_lora_targets:
         lora_sd = load_lora_state_dict(filename)
@@ -70,10 +88,16 @@ def load_networks(names, te_multipliers=None, unet_multipliers=None, dyn_dims=No
             lora_sd,
             strength_model,
             strength_clip,
+            accum_unet,
+            accum_clip,
+            unet_keys,
+            clip_keys,
             filename,
+            do_referential_load,
         )
 
     current_sd.forge_objects_after_applying_lora = current_sd.forge_objects.shallow_copy()
+
 
 
 def list_available_networks():

--- a/ldm_patched/modules/lora.py
+++ b/ldm_patched/modules/lora.py
@@ -8,6 +8,9 @@ import torch
 import ldm_patched.modules.model_management
 import ldm_patched.modules.utils
 
+LEN_WEIGHT = len(".weight")
+LEN_DIFFUSION_MODEL = len("diffusion_model.")
+
 LORA_CLIP_MAP = {
     "mlp.fc1": "mlp_fc1",
     "mlp.fc2": "mlp_fc2",
@@ -18,208 +21,235 @@ LORA_CLIP_MAP = {
 }
 
 
-def load_lora(lora, to_load):
+def load_lora(lora, known_keys, to_load, do_referential_load):
     patch_dict = {}
     loaded_keys = set()
-    for x in to_load:
-        alpha_name = "{}.alpha".format(x)
-        alpha = None
-        if alpha_name in lora.keys():
-            alpha = lora[alpha_name].item()
-            loaded_keys.add(alpha_name)
+    new_keys = set()
+    remaining_dict = lora
 
-        dora_scale_name = "{}.dora_scale".format(x)
-        dora_scale = None
-        if dora_scale_name in lora.keys():
-            dora_scale = lora[dora_scale_name]
-            loaded_keys.add(dora_scale_name)
+    if do_referential_load:
+        new_lora_keys = set()
+        for key in known_keys:
+            load_lora_key(key, to_load[key], remaining_dict, patch_dict, new_lora_keys)
+            if (len(new_lora_keys) > 0):
+                loaded_keys.update(new_lora_keys)
+                for nk in new_lora_keys:
+                    del remaining_dict[nk]
+                new_lora_keys = set()
 
-        reshape_name = "{}.reshape_weight".format(x)
-        reshape = None
-        if reshape_name in lora.keys():
-            try:
-                reshape = lora[reshape_name].tolist()
-                loaded_keys.add(reshape_name)
-            except Exception:
-                pass
+    if (len(remaining_dict) > 0):
+        new_lora_keys = set()
+        for key in to_load:
+            if key not in known_keys:
+                load_lora_key(key, to_load[key], remaining_dict, patch_dict, new_lora_keys)
+                if (len(new_lora_keys) > 0):
+                    if do_referential_load:
+                        new_keys.add(key)
+                    loaded_keys.update(new_lora_keys)
+                    for nk in new_lora_keys:
+                        del remaining_dict[nk]
+                    new_lora_keys = set()
 
-        regular_lora = "{}.lora_up.weight".format(x)
-        diffusers_lora = "{}_lora.up.weight".format(x)
-        diffusers2_lora = "{}.lora_B.weight".format(x)
-        diffusers3_lora = "{}.lora.up.weight".format(x)
-        mochi_lora = "{}.lora_B".format(x)
-        transformers_lora = "{}.lora_linear_layer.up.weight".format(x)
-        A_name = None
+    return patch_dict, remaining_dict, new_keys
 
-        if regular_lora in lora.keys():
-            A_name = regular_lora
-            B_name = "{}.lora_down.weight".format(x)
-            mid_name = "{}.lora_mid.weight".format(x)
-        elif diffusers_lora in lora.keys():
-            A_name = diffusers_lora
-            B_name = "{}_lora.down.weight".format(x)
-            mid_name = None
-        elif diffusers2_lora in lora.keys():
-            A_name = diffusers2_lora
-            B_name = "{}.lora_A.weight".format(x)
-            mid_name = None
-        elif diffusers3_lora in lora.keys():
-            A_name = diffusers3_lora
-            B_name = "{}.lora.down.weight".format(x)
-            mid_name = None
-        elif mochi_lora in lora.keys():
-            A_name = mochi_lora
-            B_name = "{}.lora_A".format(x)
-            mid_name = None
-        elif transformers_lora in lora.keys():
-            A_name = transformers_lora
-            B_name = "{}.lora_linear_layer.down.weight".format(x)
-            mid_name = None
 
-        if A_name is not None:
-            mid = None
-            if mid_name is not None and mid_name in lora.keys():
-                mid = lora[mid_name]
-                loaded_keys.add(mid_name)
-            patch_dict[to_load[x]] = ("lora", (lora[A_name], lora[B_name], alpha, mid, dora_scale, reshape))
-            loaded_keys.add(A_name)
-            loaded_keys.add(B_name)
+def load_lora_key(key, to_load_value_for_key, lora, patch_dict, loaded_keys):
+    alpha_name = "{}.alpha".format(key)
+    alpha = None
+    if alpha_name in lora.keys():
+        alpha = lora[alpha_name].item()
+        loaded_keys.add(alpha_name)
 
-        ######## loha
-        hada_w1_a_name = "{}.hada_w1_a".format(x)
-        hada_w1_b_name = "{}.hada_w1_b".format(x)
-        hada_w2_a_name = "{}.hada_w2_a".format(x)
-        hada_w2_b_name = "{}.hada_w2_b".format(x)
-        hada_t1_name = "{}.hada_t1".format(x)
-        hada_t2_name = "{}.hada_t2".format(x)
-        if hada_w1_a_name in lora.keys():
-            hada_t1 = None
-            hada_t2 = None
-            if hada_t1_name in lora.keys():
-                hada_t1 = lora[hada_t1_name]
-                hada_t2 = lora[hada_t2_name]
-                loaded_keys.add(hada_t1_name)
-                loaded_keys.add(hada_t2_name)
+    dora_scale_name = "{}.dora_scale".format(key)
+    dora_scale = None
+    if dora_scale_name in lora.keys():
+        dora_scale = lora[dora_scale_name]
+        loaded_keys.add(dora_scale_name)
 
-            patch_dict[to_load[x]] = (
-                "loha",
-                (
-                    lora[hada_w1_a_name],
-                    lora[hada_w1_b_name],
-                    alpha,
-                    lora[hada_w2_a_name],
-                    lora[hada_w2_b_name],
-                    hada_t1,
-                    hada_t2,
-                    dora_scale,
-                ),
-            )
-            loaded_keys.add(hada_w1_a_name)
-            loaded_keys.add(hada_w1_b_name)
-            loaded_keys.add(hada_w2_a_name)
-            loaded_keys.add(hada_w2_b_name)
+    reshape_name = "{}.reshape_weight".format(key)
+    reshape = None
+    if reshape_name in lora.keys():
+        try:
+            reshape = lora[reshape_name].tolist()
+            loaded_keys.add(reshape_name)
+        except Exception:
+            pass
 
-        ######## lokr
-        lokr_w1_name = "{}.lokr_w1".format(x)
-        lokr_w2_name = "{}.lokr_w2".format(x)
-        lokr_w1_a_name = "{}.lokr_w1_a".format(x)
-        lokr_w1_b_name = "{}.lokr_w1_b".format(x)
-        lokr_t2_name = "{}.lokr_t2".format(x)
-        lokr_w2_a_name = "{}.lokr_w2_a".format(x)
-        lokr_w2_b_name = "{}.lokr_w2_b".format(x)
+    regular_lora = "{}.lora_up.weight".format(key)
+    diffusers_lora = "{}_lora.up.weight".format(key)
+    diffusers2_lora = "{}.lora_B.weight".format(key)
+    diffusers3_lora = "{}.lora.up.weight".format(key)
+    mochi_lora = "{}.lora_B".format(key)
+    transformers_lora = "{}.lora_linear_layer.up.weight".format(key)
+    A_name = None
 
-        lokr_w1 = None
-        if lokr_w1_name in lora.keys():
-            lokr_w1 = lora[lokr_w1_name]
-            loaded_keys.add(lokr_w1_name)
+    if regular_lora in lora.keys():
+        A_name = regular_lora
+        B_name = "{}.lora_down.weight".format(key)
+        mid_name = "{}.lora_mid.weight".format(key)
+    elif diffusers_lora in lora.keys():
+        A_name = diffusers_lora
+        B_name = "{}_lora.down.weight".format(key)
+        mid_name = None
+    elif diffusers2_lora in lora.keys():
+        A_name = diffusers2_lora
+        B_name = "{}.lora_A.weight".format(key)
+        mid_name = None
+    elif diffusers3_lora in lora.keys():
+        A_name = diffusers3_lora
+        B_name = "{}.lora.down.weight".format(key)
+        mid_name = None
+    elif mochi_lora in lora.keys():
+        A_name = mochi_lora
+        B_name = "{}.lora_A".format(key)
+        mid_name = None
+    elif transformers_lora in lora.keys():
+        A_name = transformers_lora
+        B_name = "{}.lora_linear_layer.down.weight".format(key)
+        mid_name = None
 
-        lokr_w2 = None
-        if lokr_w2_name in lora.keys():
-            lokr_w2 = lora[lokr_w2_name]
-            loaded_keys.add(lokr_w2_name)
+    if A_name is not None:
+        mid = None
+        if mid_name is not None and mid_name in lora.keys():
+            mid = lora[mid_name]
+            loaded_keys.add(mid_name)
+        patch_dict[to_load_value_for_key] = ("lora", (lora[A_name], lora[B_name], alpha, mid, dora_scale, reshape))
+        loaded_keys.add(A_name)
+        loaded_keys.add(B_name)
 
-        lokr_w1_a = None
-        if lokr_w1_a_name in lora.keys():
-            lokr_w1_a = lora[lokr_w1_a_name]
-            loaded_keys.add(lokr_w1_a_name)
+    ######## loha
+    hada_w1_a_name = "{}.hada_w1_a".format(key)
+    hada_w1_b_name = "{}.hada_w1_b".format(key)
+    hada_w2_a_name = "{}.hada_w2_a".format(key)
+    hada_w2_b_name = "{}.hada_w2_b".format(key)
+    hada_t1_name = "{}.hada_t1".format(key)
+    hada_t2_name = "{}.hada_t2".format(key)
+    if hada_w1_a_name in lora.keys():
+        hada_t1 = None
+        hada_t2 = None
+        if hada_t1_name in lora.keys():
+            hada_t1 = lora[hada_t1_name]
+            hada_t2 = lora[hada_t2_name]
+            loaded_keys.add(hada_t1_name)
+            loaded_keys.add(hada_t2_name)
 
-        lokr_w1_b = None
-        if lokr_w1_b_name in lora.keys():
-            lokr_w1_b = lora[lokr_w1_b_name]
-            loaded_keys.add(lokr_w1_b_name)
+        patch_dict[to_load_value_for_key] = (
+            "loha",
+            (
+                lora[hada_w1_a_name],
+                lora[hada_w1_b_name],
+                alpha,
+                lora[hada_w2_a_name],
+                lora[hada_w2_b_name],
+                hada_t1,
+                hada_t2,
+                dora_scale,
+            ),
+        )
+        loaded_keys.add(hada_w1_a_name)
+        loaded_keys.add(hada_w1_b_name)
+        loaded_keys.add(hada_w2_a_name)
+        loaded_keys.add(hada_w2_b_name)
 
-        lokr_w2_a = None
-        if lokr_w2_a_name in lora.keys():
-            lokr_w2_a = lora[lokr_w2_a_name]
-            loaded_keys.add(lokr_w2_a_name)
+    ######## lokr
+    lokr_w1_name = "{}.lokr_w1".format(key)
+    lokr_w2_name = "{}.lokr_w2".format(key)
+    lokr_w1_a_name = "{}.lokr_w1_a".format(key)
+    lokr_w1_b_name = "{}.lokr_w1_b".format(key)
+    lokr_t2_name = "{}.lokr_t2".format(key)
+    lokr_w2_a_name = "{}.lokr_w2_a".format(key)
+    lokr_w2_b_name = "{}.lokr_w2_b".format(key)
 
-        lokr_w2_b = None
-        if lokr_w2_b_name in lora.keys():
-            lokr_w2_b = lora[lokr_w2_b_name]
-            loaded_keys.add(lokr_w2_b_name)
+    lokr_w1 = None
+    if lokr_w1_name in lora.keys():
+        lokr_w1 = lora[lokr_w1_name]
+        loaded_keys.add(lokr_w1_name)
 
-        lokr_t2 = None
-        if lokr_t2_name in lora.keys():
-            lokr_t2 = lora[lokr_t2_name]
-            loaded_keys.add(lokr_t2_name)
+    lokr_w2 = None
+    if lokr_w2_name in lora.keys():
+        lokr_w2 = lora[lokr_w2_name]
+        loaded_keys.add(lokr_w2_name)
 
-        if (lokr_w1 is not None) or (lokr_w2 is not None) or (lokr_w1_a is not None) or (lokr_w2_a is not None):
-            patch_dict[to_load[x]] = (
-                "lokr",
-                (lokr_w1, lokr_w2, alpha, lokr_w1_a, lokr_w1_b, lokr_w2_a, lokr_w2_b, lokr_t2, dora_scale),
-            )
+    lokr_w1_a = None
+    if lokr_w1_a_name in lora.keys():
+        lokr_w1_a = lora[lokr_w1_a_name]
+        loaded_keys.add(lokr_w1_a_name)
 
-        # glora
-        a1_name = "{}.a1.weight".format(x)
-        a2_name = "{}.a2.weight".format(x)
-        b1_name = "{}.b1.weight".format(x)
-        b2_name = "{}.b2.weight".format(x)
-        if a1_name in lora:
-            patch_dict[to_load[x]] = ("glora", (lora[a1_name], lora[a2_name], lora[b1_name], lora[b2_name], alpha, dora_scale))
-            loaded_keys.add(a1_name)
-            loaded_keys.add(a2_name)
-            loaded_keys.add(b1_name)
-            loaded_keys.add(b2_name)
+    lokr_w1_b = None
+    if lokr_w1_b_name in lora.keys():
+        lokr_w1_b = lora[lokr_w1_b_name]
+        loaded_keys.add(lokr_w1_b_name)
 
-        w_norm_name = "{}.w_norm".format(x)
-        b_norm_name = "{}.b_norm".format(x)
-        w_norm = lora.get(w_norm_name, None)
-        b_norm = lora.get(b_norm_name, None)
+    lokr_w2_a = None
+    if lokr_w2_a_name in lora.keys():
+        lokr_w2_a = lora[lokr_w2_a_name]
+        loaded_keys.add(lokr_w2_a_name)
 
-        if w_norm is not None:
-            loaded_keys.add(w_norm_name)
-            patch_dict[to_load[x]] = ("diff", (w_norm,))
-            if b_norm is not None:
-                loaded_keys.add(b_norm_name)
-                patch_dict["{}.bias".format(to_load[x][: -len(".weight")])] = ("diff", (b_norm,))
+    lokr_w2_b = None
+    if lokr_w2_b_name in lora.keys():
+        lokr_w2_b = lora[lokr_w2_b_name]
+        loaded_keys.add(lokr_w2_b_name)
 
-        diff_name = "{}.diff".format(x)
-        diff_weight = lora.get(diff_name, None)
-        if diff_weight is not None:
-            patch_dict[to_load[x]] = ("diff", (diff_weight,))
-            loaded_keys.add(diff_name)
+    lokr_t2 = None
+    if lokr_t2_name in lora.keys():
+        lokr_t2 = lora[lokr_t2_name]
+        loaded_keys.add(lokr_t2_name)
 
-        diff_bias_name = "{}.diff_b".format(x)
-        diff_bias = lora.get(diff_bias_name, None)
-        if diff_bias is not None:
-            patch_dict["{}.bias".format(to_load[x][: -len(".weight")])] = ("diff", (diff_bias,))
-            loaded_keys.add(diff_bias_name)
+    if (lokr_w1 is not None) or (lokr_w2 is not None) or (lokr_w1_a is not None) or (lokr_w2_a is not None):
+        patch_dict[to_load_value_for_key] = (
+            "lokr",
+            (lokr_w1, lokr_w2, alpha, lokr_w1_a, lokr_w1_b, lokr_w2_a, lokr_w2_b, lokr_t2, dora_scale),
+        )
 
-        set_weight_name = "{}.set_weight".format(x)
-        set_weight = lora.get(set_weight_name, None)
-        if set_weight is not None:
-            patch_dict[to_load[x]] = ("set", (set_weight,))
-            loaded_keys.add(set_weight_name)
+    # glora
+    a1_name = "{}.a1.weight".format(key)
+    a2_name = "{}.a2.weight".format(key)
+    b1_name = "{}.b1.weight".format(key)
+    b2_name = "{}.b2.weight".format(key)
+    if a1_name in lora:
+        patch_dict[to_load_value_for_key] = ("glora", (lora[a1_name], lora[a2_name], lora[b1_name], lora[b2_name], alpha, dora_scale))
+        loaded_keys.add(a1_name)
+        loaded_keys.add(a2_name)
+        loaded_keys.add(b1_name)
+        loaded_keys.add(b2_name)
 
-    remaining_dict = {x: y for x, y in lora.items() if x not in loaded_keys}
-    return patch_dict, remaining_dict
+    w_norm_name = "{}.w_norm".format(key)
+    b_norm_name = "{}.b_norm".format(key)
+    w_norm = lora.get(w_norm_name, None)
+    b_norm = lora.get(b_norm_name, None)
+
+    if w_norm is not None:
+        loaded_keys.add(w_norm_name)
+        patch_dict[to_load_value_for_key] = ("diff", (w_norm,))
+        if b_norm is not None:
+            loaded_keys.add(b_norm_name)
+            patch_dict["{}.bias".format(to_load_value_for_key[: -LEN_WEIGHT])] = ("diff", (b_norm,))
+
+    diff_name = "{}.diff".format(key)
+    diff_weight = lora.get(diff_name, None)
+    if diff_weight is not None:
+        patch_dict[to_load_value_for_key] = ("diff", (diff_weight,))
+        loaded_keys.add(diff_name)
+
+    diff_bias_name = "{}.diff_b".format(key)
+    diff_bias = lora.get(diff_bias_name, None)
+    if diff_bias is not None:
+        patch_dict["{}.bias".format(to_load_value_for_key[: -LEN_WEIGHT])] = ("diff", (diff_bias,))
+        loaded_keys.add(diff_bias_name)
+
+    set_weight_name = "{}.set_weight".format(key)
+    set_weight = lora.get(set_weight_name, None)
+    if set_weight is not None:
+        patch_dict[to_load_value_for_key] = ("set", (set_weight,))
+        loaded_keys.add(set_weight_name)
+
 
 
 def model_lora_keys_clip(model, key_map={}):
     sdk = model.state_dict().keys()
     for k in sdk:
         if k.endswith(".weight"):
-            key_map["text_encoders.{}".format(k[: -len(".weight")])] = k  # generic lora format without any weird key names
+            key_map["text_encoders.{}".format(k[: -LEN_WEIGHT])] = k  # generic lora format without any weird key names
 
     text_model_lora_key = "lora_te_text_model_encoder_layers_{}_{}"
     clip_l_present = False
@@ -271,9 +301,9 @@ def model_lora_keys_unet(model, key_map={}):
     for k in sdk:
         if k.startswith("diffusion_model."):
             if k.endswith(".weight"):
-                key_lora = k[len("diffusion_model.") : -len(".weight")].replace(".", "_")
+                key_lora = k[LEN_DIFFUSION_MODEL : -LEN_WEIGHT].replace(".", "_")
                 key_map["lora_unet_{}".format(key_lora)] = k
-                key_map["{}".format(k[: -len(".weight")])] = k  # generic lora format without any weird key names
+                key_map["{}".format(k[: -LEN_WEIGHT])] = k  # generic lora format without any weird key names
             else:
                 key_map["{}".format(k)] = k  # generic lora format for not .weight without any weird key names
 
@@ -281,13 +311,13 @@ def model_lora_keys_unet(model, key_map={}):
     for k in diffusers_keys:
         if k.endswith(".weight"):
             unet_key = "diffusion_model.{}".format(diffusers_keys[k])
-            key_lora = k[: -len(".weight")].replace(".", "_")
+            key_lora = k[: -LEN_WEIGHT].replace(".", "_")
             key_map["lora_unet_{}".format(key_lora)] = unet_key
             key_map["lycoris_{}".format(key_lora)] = unet_key  # simpletuner lycoris format
 
             diffusers_lora_prefix = ["", "unet."]
             for p in diffusers_lora_prefix:
-                diffusers_lora_key = "{}{}".format(p, k[: -len(".weight")].replace(".to_", ".processor.to_"))
+                diffusers_lora_key = "{}{}".format(p, k[: -LEN_WEIGHT].replace(".to_", ".processor.to_"))
                 if diffusers_lora_key.endswith(".to_out.0"):
                     diffusers_lora_key = diffusers_lora_key[:-2]
                 key_map[diffusers_lora_key] = unet_key

--- a/ldm_patched/modules/sd.py
+++ b/ldm_patched/modules/sd.py
@@ -29,15 +29,12 @@ def load_model_weights(model, sd):
     return model
 
 
-def load_lora_for_models(model, clip, lora, strength_model, strength_clip, filename="default"):
+def load_lora_for_models(model, clip, lora, strength_model, strength_clip, known_unet_keys = set(), known_clip_keys = set(), full_unet_keys = {}, full_clip_keys = {}, filename="default", do_referential_load=False):
     model_flag = type(model.model).__name__ if model is not None else "default"
 
-    unet_keys = ldm_patched.modules.lora.model_lora_keys_unet(model.model) if model is not None else {}
-    clip_keys = ldm_patched.modules.lora.model_lora_keys_clip(clip.cond_stage_model) if clip is not None else {}
-
     lora_unmatch = lora
-    lora_unet, lora_unmatch = ldm_patched.modules.lora.load_lora(lora_unmatch, unet_keys)
-    lora_clip, lora_unmatch = ldm_patched.modules.lora.load_lora(lora_unmatch, clip_keys)
+    lora_clip, lora_unmatch, found_clip_keys = ldm_patched.modules.lora.load_lora(lora_unmatch, known_clip_keys, full_clip_keys, do_referential_load)
+    lora_unet, lora_unmatch, found_unet_keys = ldm_patched.modules.lora.load_lora(lora_unmatch, known_unet_keys, full_unet_keys, do_referential_load)
 
     if len(lora_unmatch) > 12:
         print(f"[LORA] LoRA version mismatch for {model_flag}: {filename}")
@@ -56,6 +53,8 @@ def load_lora_for_models(model, clip, lora, strength_model, strength_clip, filen
             print(f"[LORA] Mismatch {filename} for {model_flag}-UNet with {len(skipped_keys)} keys mismatched in {len(loaded_keys)} keys")
         else:
             print(f"[LORA] Loaded {filename} for {model_flag}-UNet with {len(loaded_keys)} keys at weight {strength_model} (skipped {len(skipped_keys)} keys)")
+            if do_referential_load:
+                known_unet_keys.update(found_unet_keys)
             model = new_model
 
     if new_clip is not None and len(lora_clip) > 0:
@@ -65,6 +64,8 @@ def load_lora_for_models(model, clip, lora, strength_model, strength_clip, filen
             print(f"[LORA] Mismatch {filename} for {model_flag}-CLIP with {len(skipped_keys)} keys mismatched in {len(loaded_keys)} keys")
         else:
             print(f"[LORA] Loaded {filename} for {model_flag}-CLIP with {len(loaded_keys)} keys at weight {strength_clip} (skipped {len(skipped_keys)} keys)")
+            if do_referential_load:
+                known_clip_keys.update(found_clip_keys)
             clip = new_clip
 
     return model, clip


### PR DESCRIPTION
Hello!  Hopefully I'm not being a pain in the neck here 😅 

While trying to plan out a different possible change, I noticed a couple ways that one might be able to speed up Lora Loading by a bit when loading >1 lora in a single call to `load_lora_for_models`

Specifically:
1. Extract unet and clip keys from model once per overall lora load operation (rather than re-extract them each time each individual lora is loaded)
2. Attempt to maintain a list of "known modified" unet and clip keys.  When loading loras, parse through this list of keys first, and only parse through the full model's unet or clip key set if the lora contains keys that aren't present in the "known modified" list.

In the PR below, the first item is a non-conditional change.  I've moved the unet and clip key extraction to networks.py -> load_networks() and pass those two sets along when calling `load_lora_for_models`.  This one's a fairly small change in terms of lines of code affected.

The second item is larger in scale and gives an approximately equal performance boost from my limited testing.  First, it sets `do_referential_load` to True if there are >1 loras in the `compiled_lora_targets` list, and passes that value along in the call to `load_lora_for_models` call(s).

If that value is True in load_lora_for_models, it will maintain a separate set() each of the unet and clip that each lora has modified thus far, and will search those keys first in the `load_lora()` function.  If all the keys a given lora is modifying are found in that pass, it won't loop over the full set of unet/clip keys for that lora.  If any keys remain, it'll do the full loop and add any new keys to the known modified set() of that type.

---

Insofar as testing goes, I mostly did my testing with both of these modifications present.  All tests were performed by executing lines 74-99 of load_networks() 100 times.

I noticed that if I attempted to do Item #2 when only 1 lora is being loaded, it actually suffered about a 3-5% performance hit (thus the "do_referential_load" logic).

Using the logic below, I saw 0 performance hit for 1 lora, and roughly a 15-25% performance boost for each lora loaded beyond the first (depending on the types of loras being loaded and in what order).

My test sets were as follows:
* DMD2 speed lora, 2 unet sdxl loras, 1 tiny sdxl lora, 1 sd1.5 mismatch
* 2 unet sdxl loras, 1 tiny sdxl lora, 1 sd1.5 mismatch
* DMD2 speed lora, 2 full sdxl loras, 1 tiny sdxl lora
* 2 unet sdxl loras, 1 tiny sdxl lora
* 2 unet sdxl loras
* 2 unet sdxl loras, 1 full sdxl lora
* 1 unet sdxl loras, 1 full sdxl lora
* 1 full sdxl lora

the "unet" loras had 788 unet keys and 0 clip keys each.  the "full" lora had 722 unet and 288 clip keys.  The "tiny" lora had 4 unet and 0 clip keys.  The DMD2 speed lora had 788 unet keys that were mostly or entirely different from the other loras.

---

Feel free to drop me a line if you have any questions, concerns, or corrections.

Thanks, and sorry again for blind-siding you. 😅 