### PR TITLE
Rewrite PatchStatus Logics

### DIFF
--- a/extensions-builtin/Lora/networks.py
+++ b/extensions-builtin/Lora/networks.py
@@ -29,8 +29,6 @@ def get_networks_on_desk(names: list[str], *, tried: bool = True) -> list["netwo
 
 
 def load_networks(names, te_multipliers=None, unet_multipliers=None, dyn_dims=None):
-    global lora_state_dict_cache
-
     current_sd = sd_models.model_data.get_sd_model()
     if current_sd is None:
         return
@@ -51,14 +49,13 @@ def load_networks(names, te_multipliers=None, unet_multipliers=None, dyn_dims=No
 
     compiled_lora_targets = []
     for a, b, c in zip(networks_on_disk, unet_multipliers, te_multipliers):
-        compiled_lora_targets.append([a.filename, b, c])
+        compiled_lora_targets.append((a.filename, b, c))
 
-    compiled_lora_targets_hash = str(compiled_lora_targets)
-
-    if current_sd.current_lora_hash == compiled_lora_targets_hash:
+    if shared.cached_lora_hash == compiled_lora_targets:
         return
 
-    current_sd.current_lora_hash = compiled_lora_targets_hash
+    shared.cached_lora_hash = compiled_lora_targets
+    current_sd.current_lora_hash = str(compiled_lora_targets)
     current_sd.forge_objects.unet = current_sd.forge_objects_original.unet
     current_sd.forge_objects.clip = current_sd.forge_objects_original.clip
 

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -446,6 +446,7 @@ def load_model(checkpoint_info=None, already_loaded_state_dict=None):
 
     model_data.set_sd_model(sd_model)
     model_data.was_loaded_at_least_once = True
+    shared.cached_lora_hash.clear()
 
     # Reload embeddings after model load as they may or may not fit the model
     sd_hijack.model_hijack.embedding_db.load_textual_inversion_embeddings(force_reload=True)

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -52,6 +52,7 @@ opts = None
 restricted_opts = None
 
 sd_model: sd_models_types.WebuiSdModel = None
+cached_lora_hash: list[tuple[str, float, float]] = []  # persistent patches
 
 settings_components = None
 """assigned from ui.py, a mapping on setting names to gradio components repsponsible for those settings"""


### PR DESCRIPTION
- move the operations of `unpatch_model` function to `patch_model` function instead
    - so that when using `--persistent-patches`, if the LoRA status has changed, unpatch the model first during generation
- also updated the status logics
    - so the detections should be more correct now
- fix #117 

<hr>

- [ ] require testing for regression...