### PR TITLE
Fix API startup error by removing dead create_embedding endpoint

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -230,7 +230,6 @@ class Api:
         self.add_api_route("/sdapi/v1/refresh-embeddings", self.refresh_embeddings, methods=["POST"])
         self.add_api_route("/sdapi/v1/refresh-checkpoints", self.refresh_checkpoints, methods=["POST"])
         self.add_api_route("/sdapi/v1/refresh-vae", self.refresh_vae, methods=["POST"])
-        self.add_api_route("/sdapi/v1/create/embedding", self.create_embedding, methods=["POST"], response_model=models.CreateResponse)
         self.add_api_route("/sdapi/v1/memory", self.get_memory, methods=["GET"], response_model=models.MemoryResponse)
         self.add_api_route("/sdapi/v1/unload-checkpoint", self.unloadapi, methods=["POST"])
         self.add_api_route("/sdapi/v1/reload-checkpoint", self.reloadapi, methods=["POST"])
@@ -748,17 +747,6 @@ class Api:
     def refresh_vae(self):
         with self.queue_lock:
             shared_items.refresh_vae_list()
-
-    def create_embedding(self, args: dict):
-        try:
-            shared.state.begin(job="create_embedding")
-            filename = modules.textual_inversion.textual_inversion.create_embedding(**args) # create empty embedding
-            self.embedding_db.load_textual_inversion_embeddings(force_reload=True, sync_with_sd_model=False) # reload embeddings so new one can be immediately used
-            return models.CreateResponse(info=f"create embedding filename: {filename}")
-        except AssertionError as e:
-            return models.TrainResponse(info=f"create embedding error: {e}")
-        finally:
-            shared.state.end()
 
     def get_memory(self):
         try:


### PR DESCRIPTION
WebUI was showing an error during startup with --api flag due to a missing CreateResponse class in the embedding creation endpoint.
```
Exception in thread Thread-12 (webui_worker):
Traceback (most recent call last):
  File "C:\Python\Python310\lib\threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "C:\Python\Python310\lib\threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "F:\sd-webui-forge-classic-neo\webui.py", line 138, in webui_worker
    create_api(app)
  File "F:\sd-webui-forge-classic-neo\webui.py", line 48, in create_api
    api = Api(app, queue_lock)
  File "F:\sd-webui-forge-classic-neo\modules\api\api.py", line 233, in __init__
    self.add_api_route("/sdapi/v1/create/embedding", self.create_embedding, methods=["POST"], response_model=models.CreateResponse)
AttributeError: module 'modules.api.models' has no attribute 'CreateResponse'
```

The create_embedding function in api.py was trying to use models.CreateResponse which doesn't exist anymore. Looks like some old code got restored accidentally.

Fix
- Deleted the create_embedding function from api.py
- Removed the /sdapi/v1/create/embedding API route
