### PR TITLE
fix(api): resolve TypeError by aligning checkpoint_change/modules_cha…

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -1418,12 +1418,12 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
 
             reload = False
             if hasattr(self, 'hr_additional_modules') and 'Use same choices' not in self.hr_additional_modules:
-                modules_changed = main_entry.modules_change(self.hr_additional_modules, save=False, refresh=False)
+                modules_changed = main_entry.modules_change(self.hr_additional_modules, preset=None, save=False, refresh=False)
                 if modules_changed:
                     reload = True
 
             if self.hr_checkpoint_name and self.hr_checkpoint_name != 'Use same checkpoint':
-                checkpoint_changed = main_entry.checkpoint_change(self.hr_checkpoint_name, save=False, refresh=False)
+                checkpoint_changed = main_entry.checkpoint_change(self.hr_checkpoint_name, preset=None, save=False, refresh=False)
                 if checkpoint_changed:
                     self.firstpass_use_distilled_cfg_scale = self.sd_model.use_distilled_cfg_scale
                     reload = True
@@ -1433,8 +1433,8 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
                     main_entry.refresh_model_loading_parameters()
                     sd_models.forge_model_reload()
                 finally:
-                    main_entry.modules_change(fp_additional_modules, save=False, refresh=False)
-                    main_entry.checkpoint_change(fp_checkpoint, save=False, refresh=False)
+                    main_entry.modules_change(fp_additional_modules, preset=None, save=False, refresh=False)
+                    main_entry.checkpoint_change(fp_checkpoint, preset=None, save=False, refresh=False)
                     main_entry.refresh_model_loading_parameters()
 
             if self.sd_model.use_distilled_cfg_scale:

--- a/modules/sysinfo.py
+++ b/modules/sysinfo.py
@@ -225,11 +225,11 @@ def set_config(req: dict[str, Any], is_api=False, run_callbacks=True, save_confi
         if k == 'sd_model_checkpoint':
             if v is not None and v not in sd_models.checkpoint_aliases:
                 raise RuntimeError(f"model {v!r} not found")
-            checkpoint_changed = main_entry.checkpoint_change(v, save=False, refresh=False)
+            checkpoint_changed = main_entry.checkpoint_change(v, preset=None, save=False, refresh=False)
             if checkpoint_changed:
                 should_refresh_model_loading_params = True
         elif k == 'forge_additional_modules':
-            modules_changed = main_entry.modules_change(v, save=False, refresh=False)
+            modules_changed = main_entry.modules_change(v, preset=None, save=False, refresh=False)
             if modules_changed:
                 should_refresh_model_loading_params = True
         elif k in memory_keys:

--- a/modules_forge/main_entry.py
+++ b/modules_forge/main_entry.py
@@ -224,7 +224,8 @@ def modules_change(module_values: list, preset: str, save=True, refresh=True) ->
         return False
 
     shared.opts.set("forge_additional_modules", modules)
-    shared.opts.set(f"forge_additional_modules_{preset}", modules)
+    if preset is not None:
+        shared.opts.set(f"forge_additional_modules_{preset}", modules)
 
     if save:
         shared.opts.save(shared.config_filename)


### PR DESCRIPTION
This PR fixes an error that results in the api not working properly (at least I wasn't able to make it work without code changes).
The original error that was fixed:
```
ERROR: Exception in ASGI application
Traceback (most recent call last):
File "/home/<user>/Projects/sd-forge-neo/venv/lib/python3.11/site-packages/uvicorn/protocols/http/h11_impl.py", line 403, in run_asgi
result = await app( # type: ignore[func-returns-value]
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/<user>/Projects/sd-forge-neo/venv/lib/python3.11/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in call
return await self.app(scope, receive, send)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/<user>/Projects/sd-forge-neo/venv/lib/python3.11/site-packages/fastapi/applications.py", line 1054, in call
await super().call(scope, receive, send)
File "/home/<user>/Projects/sd-forge-neo/venv/lib/python3.11/site-packages/starlette/applications.py", line 113, in call
await self.middleware_stack(scope, receive, send)
File "/home/<user>/Projects/sd-forge-neo/venv/lib/python3.11/site-packages/starlette/middleware/errors.py", line 187, in call
raise exc
File "/home/<user>/Projects/sd-forge-neo/venv/lib/python3.11/site-packages/starlette/middleware/errors.py", line 165, in call
await self.app(scope, receive, _send)
File "/home/<user>/Projects/sd-forge-neo/venv/lib/python3.11/site-packages/gradio/route_utils.py", line 730, in call
await self.simple_response(scope, receive, send, request_headers=headers)
File "/home/<user>/Projects/sd-forge-neo/venv/lib/python3.11/site-packages/gradio/route_utils.py", line 746, in simple_response
await self.app(scope, receive, send)
File "/home/<user>/Projects/sd-forge-neo/venv/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 62, in call
await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
File "/home/<user>/Projects/sd-forge-neo/venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 62, in wrapped_app
raise exc
File "/home/<user>/Projects/sd-forge-neo/venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 51, in wrapped_app
await app(scope, receive, sender)
File "/home/<user>/Projects/sd-forge-neo/venv/lib/python3.11/site-packages/starlette/routing.py", line 715, in call
await self.middleware_stack(scope, receive, send)
File "/home/<user>/Projects/sd-forge-neo/venv/lib/python3.11/site-packages/starlette/routing.py", line 735, in app
await route.handle(scope, receive, send)
File "/home/<user>/Projects/sd-forge-neo/venv/lib/python3.11/site-packages/starlette/routing.py", line 288, in handle
await self.app(scope, receive, send)
File "/home/<user>/Projects/sd-forge-neo/venv/lib/python3.11/site-packages/starlette/routing.py", line 76, in app
await wrap_app_handling_exceptions(app, request)(scope, receive, send)
File "/home/<user>/Projects/sd-forge-neo/venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 62, in wrapped_app
raise exc
File "/home/<user>/Projects/sd-forge-neo/venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 51, in wrapped_app
await app(scope, receive, sender)
File "/home/<user>/Projects/sd-forge-neo/venv/lib/python3.11/site-packages/starlette/routing.py", line 73, in app
response = await f(request)
^^^^^^^^^^^^^^^^
File "/home/<user>/Projects/sd-forge-neo/venv/lib/python3.11/site-packages/fastapi/routing.py", line 301, in app
raw_response = await run_endpoint_function(
^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/<user>/Projects/sd-forge-neo/venv/lib/python3.11/site-packages/fastapi/routing.py", line 214, in run_endpoint_function
return await run_in_threadpool(dependant.call, **values)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/<user>/Projects/sd-forge-neo/venv/lib/python3.11/site-packages/starlette/concurrency.py", line 39, in run_in_threadpool
return await anyio.to_thread.run_sync(func, *args)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/<user>/Projects/sd-forge-neo/venv/lib/python3.11/site-packages/anyio/to_thread.py", line 33, in run_sync
return await get_asynclib().run_sync_in_worker_thread(
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/<user>/Projects/sd-forge-neo/venv/lib/python3.11/site-packages/anyio/_backends/_asyncio.py", line 877, in run_sync_in_worker_thread
return await future
^^^^^^^^^^^^
File "/home/<user>/Projects/sd-forge-neo/venv/lib/python3.11/site-packages/anyio/_backends/_asyncio.py", line 807, in run
result = context.run(func, *args)
^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/<user>/Projects/sd-forge-neo/modules/api/api.py", line 490, in text2imgapi
processed = process_images(p)
^^^^^^^^^^^^^^^^^
File "/home/<user>/Projects/sd-forge-neo/modules/processing.py", line 822, in process_images
set_config(p.override_settings, is_api=True, run_callbacks=False, save_config=False)
File "/home/<user>/Projects/sd-forge-neo/modules/sysinfo.py", line 228, in set_config
checkpoint_changed = main_entry.checkpoint_change(v, save=False, refresh=False)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: checkpoint_change() missing 1 required positional argument: 'preset'
```