### PR TITLE
Cut VRAM usage by half with just one flag!

### DIFF
--- a/ldm_patched/modules/sd.py
+++ b/ldm_patched/modules/sd.py
@@ -9,9 +9,16 @@ import ldm_patched.modules.utils
 import ldm_patched.taesd.taesd
 from ldm_patched.ldm.models.autoencoder import AutoencoderKL
 from ldm_patched.modules import model_management
-from modules.shared import opts
+from modules.shared import cmd_opts, opts
 
 from . import diffusers_convert
+
+try:
+    from accelerate.utils import BnbQuantizationConfig, load_and_quantize_model
+except ImportError:
+    use_nf4 = False
+else:
+    use_nf4 = cmd_opts.nf4
 
 
 def load_model_weights(model, sd):
@@ -194,16 +201,32 @@ class VAE:
         offload_device = model_management.vae_offload_device()
         if dtype is None:
             dtype = model_management.vae_dtype()
+        if use_nf4:
+            dtype = torch.float16
         print("VAE dtype:", dtype)
         self.vae_dtype = dtype
         self.first_stage_model.to(self.vae_dtype)
         self.output_device = model_management.intermediate_device()
+
+        if use_nf4:
+            self.first_stage_model = load_and_quantize_model(
+                self.first_stage_model,
+                bnb_quantization_config=BnbQuantizationConfig(
+                    load_in_4bit=True,
+                    bnb_4bit_quant_type="nf4",
+                    bnb_4bit_compute_dtype="fp16",
+                    torch_dtype="fp16",
+                ),
+            ).eval()
 
         self.patcher = ldm_patched.modules.model_patcher.ModelPatcher(
             self.first_stage_model,
             load_device=self.device,
             offload_device=offload_device,
         )
+
+        if use_nf4:
+            model_management.load_model_gpu(self.patcher)
 
     def clone(self):
         n = VAE(no_init=True)

--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -27,6 +27,7 @@ parser.add_argument("--ckpt-dir", type=normalized_filepath, default=None, help="
 parser.add_argument("--vae-dir", type=normalized_filepath, default=None, help="Path to directory with VAE files")
 parser.add_argument("--gfpgan-dir", type=normalized_filepath, help="GFPGAN directory", default=("./src/gfpgan" if os.path.exists("./src/gfpgan") else "./GFPGAN"))
 parser.add_argument("--gfpgan-model", type=normalized_filepath, help="GFPGAN model file name", default=None)
+parser.add_argument("--nf4", action="store_true", help="load unet and vae in 4-bit precision")
 parser.add_argument("--no-half", action="store_true", help="do not switch the model to 16-bit floats")
 parser.add_argument("--embeddings-dir", type=normalized_filepath, default=os.path.join(models_path, "embeddings"), help="textual inversion directory")
 parser.add_argument("--localizations-dir", type=normalized_filepath, default=os.path.join(script_path, "localizations"), help="localizations directory")

--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -335,6 +335,14 @@ def prepare_environment():
         run_pip(f'install -r "{requirements_file}"', "requirements")
         startup_timer.record("install requirements")
 
+    if args.nf4:
+        if not is_installed("accelerate"):
+            acc_package = os.environ.get("ACC_PACKAGE", "accelerate==1.10.1")
+            run_pip(f"install {acc_package}", "accelerate")
+        if not is_installed("bitsandbytes"):
+            bnb_package = os.environ.get("BNB_PACKAGE", "bitsandbytes==0.48.1")
+            run_pip(f"install {bnb_package}", "bitsandbytes")
+
     if not is_installed("insightface"):
         try:
             run_pip(f"install --no-deps {insightface_package}", "insightface")

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -1,13 +1,10 @@
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    import torch
-
 import collections
 import glob
 import os
 from copy import deepcopy
 from dataclasses import dataclass
+
+import torch
 
 from modules import extra_networks, hashes, paths, script_callbacks, sd_hijack, sd_models, sd_samplers_common, shared  # noqa
 
@@ -16,7 +13,7 @@ vae_ignore_keys = {"model_ema.decay", "model_ema.num_updates"}
 vae_dict = {}
 
 
-base_vae: collections.OrderedDict[str, "torch.Tensor"] = None
+base_vae: collections.OrderedDict[str, torch.Tensor] = None
 loaded_vae_file: os.PathLike = None
 checkpoint_info: "sd_models.CheckpointInfo" = None
 
@@ -237,7 +234,7 @@ def load_vae(model, vae_file=None, vae_source="from unknown source"):
     model.loaded_vae_file = loaded_vae_file
 
 
-# don't call this from outside
+@torch.inference_mode()
 def _load_vae_dict(model, vae_dict_1):
     model.first_stage_model.load_state_dict(vae_dict_1)
 

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -1,10 +1,13 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import torch
+
 import collections
 import glob
 import os
 from copy import deepcopy
 from dataclasses import dataclass
-
-import torch
 
 from modules import extra_networks, hashes, paths, script_callbacks, sd_hijack, sd_models, sd_samplers_common, shared  # noqa
 
@@ -13,7 +16,7 @@ vae_ignore_keys = {"model_ema.decay", "model_ema.num_updates"}
 vae_dict = {}
 
 
-base_vae: collections.OrderedDict[str, torch.Tensor] = None
+base_vae: collections.OrderedDict[str, "torch.Tensor"] = None
 loaded_vae_file: os.PathLike = None
 checkpoint_info: "sd_models.CheckpointInfo" = None
 
@@ -234,7 +237,7 @@ def load_vae(model, vae_file=None, vae_source="from unknown source"):
     model.loaded_vae_file = loaded_vae_file
 
 
-@torch.inference_mode()
+# don't call this from outside
 def _load_vae_dict(model, vae_dict_1):
     model.first_stage_model.load_state_dict(vae_dict_1)
 

--- a/modules_forge/forge_loader.py
+++ b/modules_forge/forge_loader.py
@@ -1,4 +1,5 @@
 import contextlib
+import logging
 
 import torch
 from omegaconf import OmegaConf
@@ -15,6 +16,14 @@ from modules.sd_models_config import find_checkpoint_config
 from modules.sd_models_types import WebuiSdModel
 from modules_forge import forge_clip
 from modules_forge.unet_patcher import UnetPatcher
+
+try:
+    from accelerate.utils import BnbQuantizationConfig, load_and_quantize_model
+except ImportError:
+    use_nf4 = False
+else:
+    use_nf4 = shared.cmd_opts.nf4
+    logging.getLogger("accelerate.utils.bnb").setLevel(logging.ERROR)
 
 
 class FakeObject:
@@ -67,10 +76,26 @@ def load_checkpoint_guess_config(sd, output_vae=True, output_clip=True, output_c
             clipvision = ldm_patched.modules.clip_vision.load_clipvision_from_sd(sd, model_config.clip_vision_prefix, True)
 
     if output_model:
-        initial_load_device = model_management.unet_initial_load_device(parameters, unet_dtype)
-        print("UNet dtype:", unet_dtype)
+        if use_nf4:
+            initial_load_device = load_device
+            print("UNet dtype:", "nf4 (LoRA is not Supported)")
+        else:
+            initial_load_device = model_management.unet_initial_load_device(parameters, unet_dtype)
+            print("UNet dtype:", unet_dtype)
+
         model = model_config.get_model(sd, "model.diffusion_model.", device=initial_load_device)
         model.load_model_weights(sd, "model.diffusion_model.")
+
+        if use_nf4:
+            model = load_and_quantize_model(
+                model,
+                bnb_quantization_config=BnbQuantizationConfig(
+                    load_in_4bit=True,
+                    bnb_4bit_quant_type="nf4",
+                    bnb_4bit_compute_dtype="fp16",
+                    torch_dtype="fp16",
+                ),
+            ).eval()
 
         unet = UnetPatcher(
             model,


### PR DESCRIPTION
~~Ignore the fact that it uses double the VRAM to quantize the model first~~ 🤫

### How to Use
```bash
--nf4
```

### What it Does
Load the UNet and VAE in `nf4` precision, and reduce the peak VRAM usage (`SDXL`) from `~7 GB` to `~4 GB`, with **no** quality and inference speed degradation

> [!Important]
> LoRA does **not** work...