### PR TITLE
Fix for Inpaint Noobai 

### DIFF
--- a/extensions-builtin/forge_preprocessor_inpaint/scripts/preprocessor_inpaint.py
+++ b/extensions-builtin/forge_preprocessor_inpaint/scripts/preprocessor_inpaint.py
@@ -172,7 +172,7 @@ class PreprocessorInpaintLama(PreprocessorInpaintOnly):
         return cond, mask
 
 
-class PreprocessorInpaintNoobAIXL(PreprocessorInpaint):
+class PreprocessorInpaintNoobAIXL(PreprocessorInpaintOnly):
     def __init__(self):
         super().__init__()
         self.name = "inpaint_noobai"
@@ -216,7 +216,8 @@ class PreprocessorInpaintNoobAIXL(PreprocessorInpaint):
 
         mask = mask.round()
         mixed_cond = cond * (1.0 - mask)
-
+        _, _ = super().process_before_every_sampling(process, cond, mask, *args, **kwargs)
+        
         return mixed_cond, None
 
 


### PR DESCRIPTION
Fix for Inpaint Noobai: previously, non-painted areas were also being modified during image inpainting.  
This update ensures that only the painted regions are affected.  

Some users reported that the image appeared faded — this was caused by global modifications affecting the entire image.  
The fix addresses this issue.  

Note: I wasn’t able to pull the neo branch, so this code is based on and modifies neo Inpaint Noobai.