### PR TITLE
Add support for torch nightly 2.10

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -503,4 +503,3 @@ def dump_sysinfo():
         file.write(text)
 
     return filename
-

--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -94,7 +94,7 @@ def _torch_version() -> str:
 
     ver = importlib.metadata.version("torch")
     ver = ver.split("+", 1)[0]
-    assert len(ver.split(".")) == 3
+    ver = ".".join(ver.split(".")[:3])
     return ver
 
 
@@ -504,3 +504,4 @@ def dump_sysinfo():
         file.write(text)
 
     return filename
+

--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -94,8 +94,7 @@ def _torch_version() -> str:
 
     ver = importlib.metadata.version("torch")
     ver = ver.split("+", 1)[0]
-    ver = ".".join(ver.split(".")[:3])
-    return ver
+    return re.search(r"[\d.]+[\d]", ver).group(0)
 
 
 def is_installed(package):
@@ -504,3 +503,4 @@ def dump_sysinfo():
         file.write(text)
 
     return filename
+

--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -504,4 +504,3 @@ def dump_sysinfo():
         file.write(text)
 
     return filename
-


### PR DESCRIPTION
At the moment when trying to use torch nightly 2.10, you get this issue:

```
Python 3.12.12 (main, Oct 10 2025, 00:00:00) [GCC 15.2.1 20250808 (Red Hat 15.2.1-1)]
Version: neo
Traceback (most recent call last):
  File "/run/media/pancho/MX500/cosas_linux/sd/neo/launch.py", line 52, in <module>
    main()
  File "/run/media/pancho/MX500/cosas_linux/sd/neo/launch.py", line 41, in main
    prepare_environment()
  File "/run/media/pancho/MX500/cosas_linux/sd/neo/modules/launch_utils.py", line 326, in prepare_environment
    ver_TORCH = _torch_version()
                ^^^^^^^^^^^^^^^^
  File "/run/media/pancho/MX500/cosas_linux/sd/neo/modules/launch_utils.py", line 97, in _torch_version
    assert len(ver.split(".")) == 3
           ^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```

This changes forces the version to has 3 parts by taking only the first 3 components, so
```
2.10.0.dev20251115+cu130 → 2.10.0
2.4.1+cu121 → 2.4.1
2.3.0 → 2.3.0
```

If there's a better way for this check let me know!