### PR TITLE
Revert "Add support for torch nightly 2.10"

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -94,7 +94,8 @@ def _torch_version() -> str:
 
     ver = importlib.metadata.version("torch")
     ver = ver.split("+", 1)[0]
-    return re.search(r"[\d.]+[\d]", ver).group(0)
+    assert len(ver.split(".")) == 3
+    return ver
 
 
 def is_installed(package):


### PR DESCRIPTION
Reverts Haoming02/sd-webui-forge-classic#372

I noticed that after this PR, when doing grids of more than 1 image, the output is not in the gallery, so it looks like this (just 1 image when doing bs 2 and bc 2)

<img width="3738" height="1174" alt="imagen" src="https://github.com/user-attachments/assets/b160c582-1d06-4891-8b14-fa8672e37cea" />


So reverting makes it work again (or doing `git checkout 4f27ac0`)

A simpler way to fix would be just commenting or removing out the assert.

```
def _torch_version() -> str:
    import importlib.metadata

    ver = importlib.metadata.version("torch")
    ver = ver.split("+", 1)[0]
    # assert len(ver.split(".")) == 3
    return ver
```

Sorry!

