### PR TITLE
Revert "Add support for torch nightly 2.10"

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -94,8 +94,8 @@ def _torch_version() -> str:
 
     ver = importlib.metadata.version("torch")
     ver = ver.split("+", 1)[0]
-    return re.search(r"[\d.]+[\d]", ver).group(0)
-
+    assert len(ver.split(".")) == 3
+    return ver
 
 def is_installed(package):
     try:


### PR DESCRIPTION
Reverts Haoming02/sd-webui-forge-classic#372

I noticed that after this PR, when doing grids of more than 1 image, the output is not in the gallery, so it looks like this (just 1 image when doing bs 2 and bc 2)

<img width="3738" height="1174" alt="imagen" src="https://github.com/user-attachments/assets/b160c582-1d06-4891-8b14-fa8672e37cea" />


So reverting makes it work again (or doing `git checkout 4f27ac0`)

A simpler way to fix would be just commenting or removing out the assert.

```
def _torch_version() -> str:
    import importlib.metadata

    ver = importlib.metadata.version("torch")
    ver = ver.split("+", 1)[0]
    # assert len(ver.split(".")) == 3
    return ver
```

Sorry!

As more info:

SD is running on another PC, so I connect via http://SD_PC:port

When using a single image, it works

<img width="3783" height="1875" alt="516576491-740e5763-e090-457b-918f-9cbce3728f9d" src="https://github.com/user-attachments/assets/9aab6972-73af-40b8-91d0-21cfbfc9b5d9" />

But when doing 2x2, I get this if I didn't do a gen before (basically empty gallery)

<img width="3801" height="1838" alt="516576766-dc37c593-32ad-47fa-bf8c-0322c5f625c0" src="https://github.com/user-attachments/assets/5979ea42-86dc-482b-9421-b58ae501fc77" />

Also noticed when generating, it shows the preview, but it says that network error

<img width="3798" height="1830" alt="516576730-7a3f263a-6c65-4483-803e-ddeae24dc52b" src="https://github.com/user-attachments/assets/4c91609f-08f4-4523-a820-c68f3366cb06" />

To add: I do use SD with a password.

Enabled loglevel DEBUG and the output says this:

```
Startup time: 10.6s (prepare environment: 2.1s, launcher: 0.1s, import torch: 2.9s, forge init: 1.0s, other imports: 0.3s, load scripts: 1.5s, create ui: 1.2s, gradio launch: 1.3s, add APIs: 0.9s).
2025-11-19 22:44:15 DEBUG [python_multipart.multipart] Calling on_part_begin with no data
2025-11-19 22:44:15 DEBUG [python_multipart.multipart] Calling on_header_field with data[57:76]
2025-11-19 22:44:15 DEBUG [python_multipart.multipart] Calling on_header_value with data[78:104]
2025-11-19 22:44:15 DEBUG [python_multipart.multipart] Calling on_header_end with no data
2025-11-19 22:44:15 DEBUG [python_multipart.multipart] Calling on_headers_finished with no data
2025-11-19 22:44:15 DEBUG [python_multipart.multipart] Calling on_part_data with data[108:115]
2025-11-19 22:44:15 DEBUG [python_multipart.multipart] Calling on_part_end with no data
2025-11-19 22:44:15 DEBUG [python_multipart.multipart] Calling on_part_begin with no data
2025-11-19 22:44:15 DEBUG [python_multipart.multipart] Calling on_header_field with data[174:193]
2025-11-19 22:44:15 DEBUG [python_multipart.multipart] Calling on_header_value with data[195:221]
2025-11-19 22:44:15 DEBUG [python_multipart.multipart] Calling on_header_end with no data
2025-11-19 22:44:15 DEBUG [python_multipart.multipart] Calling on_headers_finished with no data
2025-11-19 22:44:15 DEBUG [python_multipart.multipart] Calling on_part_data with data[225:235]
2025-11-19 22:44:15 DEBUG [python_multipart.multipart] Calling on_part_end with no data
2025-11-19 22:44:15 DEBUG [python_multipart.multipart] Calling on_end with no data
2025-11-19 22:44:18 DEBUG [matplotlib.pyplot] Loaded backend tkagg version 8.6.
2025-11-19 22:44:18 DEBUG [matplotlib.pyplot] Loaded backend agg version v2.2.
2025-11-19 22:44:18 DEBUG [matplotlib.pyplot] Loaded backend tkagg version 8.6.
2025-11-19 22:44:18 DEBUG [matplotlib.pyplot] Loaded backend agg version v2.2.
2025-11-19 22:44:18 DEBUG [matplotlib.pyplot] Loaded backend tkagg version 8.6.
Skipping broken symlink: /run/media/pancho/MX500/cosas_linux/sd/neo/models/Stable-diffusion/NoobAI-XL-Vpred-v1.0+v29b-v2-perpendicular-cyberfixv4_alt_v2.safetensors
Skipping broken symlink: /run/media/pancho/MX500/cosas_linux/sd/neo/models/Stable-diffusion/NoobAI-XL-Vpred-v1.0-perpendicular-cyberfixv4_alt_v2.safetensors
2025-11-19 22:44:18 DEBUG [matplotlib.pyplot] Loaded backend agg version v2.2.
2025-11-19 22:44:18 DEBUG [git.cmd] Popen(['git', 'remote', 'get-url', '--all', 'origin'], cwd=/run/media/pancho/MX500/cosas_linux/sd/neo, stdin=None, shell=False, universal_newlines=False)
2025-11-19 22:44:18 DEBUG [git.cmd] Popen(['git', 'cat-file', '--batch-check'], cwd=/run/media/pancho/MX500/cosas_linux/sd/neo, stdin=<valid stream>, shell=False, universal_newlines=False)
2025-11-19 22:44:18 DEBUG [git.cmd] Popen(['git', 'cat-file', '--batch'], cwd=/run/media/pancho/MX500/cosas_linux/sd/neo, stdin=<valid stream>, shell=False, universal_newlines=False)
Environment vars changed: {'stream': False, 'inference_memory': 2038.4, 'pin_shared_memory': False}
[GPU Setting] You will use 93.62% GPU memory (30061.00 MB) to load weights, and use 6.38% GPU memory (2048.00 MB) to do matrix computation.
2025-11-19 22:44:18 DEBUG [git.cmd] Popen(['git', 'remote', 'get-url', '--all', 'origin'], cwd=/run/media/pancho/MX500/cosas_linux/sd/neo, stdin=None, shell=False, universal_newlines=False)
2025-11-19 22:44:18 DEBUG [git.cmd] Popen(['git', 'cat-file', '--batch-check'], cwd=/run/media/pancho/MX500/cosas_linux/sd/neo, stdin=<valid stream>, shell=False, universal_newlines=False)
2025-11-19 22:44:18 DEBUG [git.cmd] Popen(['git', 'cat-file', '--batch'], cwd=/run/media/pancho/MX500/cosas_linux/sd/neo, stdin=<valid stream>, shell=False, universal_newlines=False)
2025-11-19 22:44:47 INFO [modules.shared_state] Starting job task(uopefw78dx5evrx)
Loading Model: {'checkpoint_info': {'filename': '/run/media/pancho/MX500/cosas_linux/sd/neo/models/Stable-diffusion/actualws/xlmodels/illu-noob/naiXLVpred102d_colorized.safetensors', 'hash': 'bc220902'}, 'additional_modules': ['/run/media/pancho/MX500/cosas_linux/sd/neo/models/VAE/SDXL Anime VAE Dec-only B3.safetensors'], 'unet_storage_dtype': None}
[Unload] Trying to free all memory for cuda:0 with 0 models keep loaded ... Done.
StateDict Keys: {'unet': 1680, 'vae': 248, 'text_encoder': 197, 'text_encoder_2': 518, 'ignore': 0}
Working with z of shape (1, 4, 32, 32) = 4096 dimensions.
K-Model Created: {'storage_dtype': torch.float16, 'computation_dtype': torch.float16}
Model loaded in 0.9s (unload existing model: 0.3s, forge model load: 0.6s).
2025-11-19 22:44:47 INFO [sd_dynamic_prompts.dynamic_prompting] Prompt matrix will create 4 images in a total of 2 batches.
                                  [Unload] Trying to free 4141.61 MB for cuda:0 with 0 models keep loaded ... Done.
Moving model(s) has taken 0.13 seconds
[Unload] Trying to free 2038.40 MB for cuda:0 with 1 models keep loaded ... Done.
[Unload] Trying to free 2038.40 MB for cuda:0 with 1 models keep loaded ... Done.
[Unload] Trying to free 2038.40 MB for cuda:0 with 1 models keep loaded ... Done.
[Unload] Trying to free 7711.37 MB for cuda:0 with 0 models keep loaded ... Done.
Moving model(s) has taken 0.01 seconds
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 25/25 [00:08<00:00,  2.85it/s]
[Unload] Trying to free 4641.19 MB for cuda:0 with 0 models keep loaded ... Done.                                                               | 25/70 [00:09<00:15,  2.91it/s]
Moving model(s) has taken 0.01 seconds
[Unload] Trying to free 2038.40 MB for cuda:0 with 0 models keep loaded ... Done.
Cleanup minimal inference memory...
2025-11-19 22:44:57 INFO [modules.modelloader] Loaded PLKSR Model: "4xBHI_realplksr_dysample_multi.pth"
2025-11-19 22:44:57 DEBUG [modules.modelloader] Loaded <spandrel.architectures.PLKSR.PLKSRArch object at 0x7fb323b6aae0> from /run/media/pancho/MX500/cosas_linux/sd/neo/models/ESRGAN/4xBHI_realplksr_dysample_multi.pth (device=cpu, half=False, dtype=None)
2025-11-19 22:44:57 DEBUG [modules.upscaler_utils] Tile (0, 0) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB3134993A0>...
2025-11-19 22:44:57 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310AAF800> (scale factor 4)
2025-11-19 22:44:57 DEBUG [modules.upscaler_utils] Tile (213, 0) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB312C154F0>...
2025-11-19 22:44:57 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BD70B0> (scale factor 4)
2025-11-19 22:44:57 DEBUG [modules.upscaler_utils] Tile (426, 0) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E35E20>...
2025-11-19 22:44:57 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BD61B0> (scale factor 4)
2025-11-19 22:44:57 DEBUG [modules.upscaler_utils] Tile (640, 0) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB313A36060>...
2025-11-19 22:44:57 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BD7F80> (scale factor 4)
2025-11-19 22:44:57 DEBUG [modules.upscaler_utils] Tile (0, 208) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310AAFA70>...
2025-11-19 22:44:57 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BD79E0> (scale factor 4)
2025-11-19 22:44:57 DEBUG [modules.upscaler_utils] Tile (213, 208) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310BB60C0>...
2025-11-19 22:44:57 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BD6BA0> (scale factor 4)
2025-11-19 22:44:57 DEBUG [modules.upscaler_utils] Tile (426, 208) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB314BC78C0>...
2025-11-19 22:44:57 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BD63C0> (scale factor 4)
2025-11-19 22:44:57 DEBUG [modules.upscaler_utils] Tile (640, 208) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB314BC6DE0>...
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BD7E60> (scale factor 4)
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] Tile (0, 416) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310AAE810>...
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BD7CB0> (scale factor 4)
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] Tile (213, 416) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB314BC5C40>...
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BD7DD0> (scale factor 4)
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] Tile (426, 416) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB314BC59A0>...
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BD7710> (scale factor 4)
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] Tile (640, 416) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB314BC4860>...
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310AACCE0> (scale factor 4)
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] Tile (0, 624) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB314BC70E0>...
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310AAC920> (scale factor 4)
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] Tile (213, 624) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB314BC4440>...
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310AACBF0> (scale factor 4)
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] Tile (426, 624) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB31AD7E990>...
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310AACC80> (scale factor 4)
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] Tile (640, 624) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB31AE1DEB0>...
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310AAD4F0> (scale factor 4)
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] Tile (0, 832) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB314BC6750>...
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310AACA10> (scale factor 4)
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] Tile (213, 832) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310BD5250>...
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310AAD700> (scale factor 4)
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] Tile (426, 832) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310BD54C0>...
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310AAC980> (scale factor 4)
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] Tile (640, 832) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310BD5AC0>...
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB315582840> (scale factor 4)
tiled upscale (CPU Composite): 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 20/20 [00:00<00:00, 25.99it/s]
[Unload] Trying to free 2038.40 MB for cuda:0 with 0 models keep loaded ... Done.                                                               | 25/70 [00:10<00:15,  2.91it/s]
Cleanup minimal inference memory...
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] Tile (0, 0) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB313B9A9C0>...
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310AAD4F0> (scale factor 4)
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] Tile (213, 0) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310BB67E0>...
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310AAD670> (scale factor 4)
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] Tile (426, 0) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310BB5070>...
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310AACC80> (scale factor 4)
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] Tile (640, 0) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB314BC50D0>...
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310AACD70> (scale factor 4)
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] Tile (0, 208) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310BB47D0>...
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310AACC50> (scale factor 4)
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] Tile (213, 208) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB314BC4440>...
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BD5700> (scale factor 4)
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] Tile (426, 208) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB314BC7CE0>...
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310AAFFB0> (scale factor 4)
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] Tile (640, 208) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB314BC5610>...
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB313569700> (scale factor 4)
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] Tile (0, 416) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB314BC4050>...
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BD4AA0> (scale factor 4)
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] Tile (213, 416) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB314BC7A10>...
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BD7770> (scale factor 4)
2025-11-19 22:44:58 DEBUG [modules.upscaler_utils] Tile (426, 416) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB314BC6F60>...
2025-11-19 22:44:59 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BD7620> (scale factor 4)
2025-11-19 22:44:59 DEBUG [modules.upscaler_utils] Tile (640, 416) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB314BC7800>...
2025-11-19 22:44:59 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BD6FC0> (scale factor 4)
2025-11-19 22:44:59 DEBUG [modules.upscaler_utils] Tile (0, 624) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB314BC6750>...
2025-11-19 22:44:59 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BD4050> (scale factor 4)
2025-11-19 22:44:59 DEBUG [modules.upscaler_utils] Tile (213, 624) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB31AFEBAD0>...
2025-11-19 22:44:59 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BD75C0> (scale factor 4)
2025-11-19 22:44:59 DEBUG [modules.upscaler_utils] Tile (426, 624) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB31AFEBCB0>...
2025-11-19 22:44:59 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BD7980> (scale factor 4)
2025-11-19 22:44:59 DEBUG [modules.upscaler_utils] Tile (640, 624) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB31AFEA840>...
2025-11-19 22:44:59 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BD6DE0> (scale factor 4)
2025-11-19 22:44:59 DEBUG [modules.upscaler_utils] Tile (0, 832) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB313AEF6B0>...
2025-11-19 22:44:59 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BD7DA0> (scale factor 4)
2025-11-19 22:44:59 DEBUG [modules.upscaler_utils] Tile (213, 832) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E373E0>...
2025-11-19 22:44:59 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310AACA10> (scale factor 4)
2025-11-19 22:44:59 DEBUG [modules.upscaler_utils] Tile (426, 832) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB3135ED430>...
2025-11-19 22:44:59 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BD7080> (scale factor 4)
2025-11-19 22:44:59 DEBUG [modules.upscaler_utils] Tile (640, 832) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310AAD520>...
2025-11-19 22:44:59 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BD7B30> (scale factor 4)
tiled upscale (CPU Composite): 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 20/20 [00:00<00:00, 27.16it/s]
[Unload] Trying to free 7792.41 MB for cuda:0 with 1 models keep loaded ... Done.                                                               | 25/70 [00:11<00:15,  2.91it/s]
[Unload] Trying to free 7792.41 MB for cuda:0 with 1 models keep loaded ... Done.
[Unload] Trying to free 16850.56 MB for cuda:0 with 1 models keep loaded ... Done.
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:03<00:00,  2.87it/s]
[Unload] Trying to free 9511.87 MB for cuda:0 with 1 models keep loaded ... Done.█▌                                                             | 35/70 [00:15<00:13,  2.66it/s]
[Unload] Trying to free 7711.36 MB for cuda:0 with 1 models keep loaded ... Done.
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 25/25 [00:08<00:00,  2.89it/s]
[Unload] Trying to free 4449.72 MB for cuda:0 with 1 models keep loaded ... Done.█████████████████████████████████████████████▍                 | 60/70 [00:24<00:03,  2.87it/s]
[Unload] Trying to free 2038.40 MB for cuda:0 with 0 models keep loaded ... Done.
Cleanup minimal inference memory...
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] Tile (0, 0) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB313BB9700>...
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB6DB0> (scale factor 4)
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] Tile (213, 0) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB31AE1D7F0>...
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB41A0> (scale factor 4)
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] Tile (426, 0) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB3147DEF00>...
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB64E0> (scale factor 4)
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] Tile (640, 0) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E35070>...
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB3158B8890> (scale factor 4)
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] Tile (0, 208) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB313BB8B90>...
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310E35940> (scale factor 4)
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] Tile (213, 208) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E340E0>...
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310E37DA0> (scale factor 4)
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] Tile (426, 208) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E37200>...
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310E37380> (scale factor 4)
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] Tile (640, 208) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E35970>...
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310E34E60> (scale factor 4)
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] Tile (0, 416) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E37050>...
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB3158B95E0> (scale factor 4)
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] Tile (213, 416) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E36210>...
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB3147DC9E0> (scale factor 4)
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] Tile (426, 416) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E35A30>...
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310E372C0> (scale factor 4)
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] Tile (640, 416) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E357C0>...
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB65D0> (scale factor 4)
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] Tile (0, 624) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E36840>...
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB4FB0> (scale factor 4)
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] Tile (213, 624) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E347A0>...
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB6780> (scale factor 4)
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] Tile (426, 624) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E34A10>...
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB66F0> (scale factor 4)
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] Tile (640, 624) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E34C50>...
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB6960> (scale factor 4)
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] Tile (0, 832) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E376B0>...
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB6D80> (scale factor 4)
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] Tile (213, 832) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310BB6DE0>...
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB7D40> (scale factor 4)
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] Tile (426, 832) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310BB5760>...
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB5610> (scale factor 4)
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] Tile (640, 832) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310BB59A0>...
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB4860> (scale factor 4)
tiled upscale (CPU Composite): 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 20/20 [00:00<00:00, 27.09it/s]
[Unload] Trying to free 2038.40 MB for cuda:0 with 0 models keep loaded ... Done.█████████████████████████████████████████████▍                 | 60/70 [00:25<00:03,  2.87it/s]
Cleanup minimal inference memory...
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] Tile (0, 0) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB3158BAC30>...
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB5A00> (scale factor 4)
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] Tile (213, 0) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E37A10>...
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB6DE0> (scale factor 4)
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] Tile (426, 0) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E347A0>...
2025-11-19 22:45:13 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB4FE0> (scale factor 4)
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] Tile (640, 0) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E36840>...
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB4620> (scale factor 4)
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] Tile (0, 208) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310C6AF00>...
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB5760> (scale factor 4)
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] Tile (213, 208) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E37230>...
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB7170> (scale factor 4)
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] Tile (426, 208) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E35B20>...
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB55E0> (scale factor 4)
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] Tile (640, 208) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E36180>...
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB4860> (scale factor 4)
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] Tile (0, 416) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E35460>...
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB52E0> (scale factor 4)
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] Tile (213, 416) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E35DC0>...
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB70E0> (scale factor 4)
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] Tile (426, 416) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E35400>...
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB6780> (scale factor 4)
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] Tile (640, 416) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E373E0>...
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB6960> (scale factor 4)
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] Tile (0, 624) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E37050>...
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB7C80> (scale factor 4)
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] Tile (213, 624) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E35100>...
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB71D0> (scale factor 4)
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] Tile (426, 624) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E35D00>...
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB60C0> (scale factor 4)
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] Tile (640, 624) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E35C40>...
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB66F0> (scale factor 4)
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] Tile (0, 832) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E35940>...
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB64E0> (scale factor 4)
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] Tile (213, 832) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E37DA0>...
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB75C0> (scale factor 4)
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] Tile (426, 832) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E35280>...
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB6750> (scale factor 4)
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] Tile (640, 832) <PIL.Image.Image image mode=RGB size=256x256 at 0x7FB310E35AF0>...
2025-11-19 22:45:14 DEBUG [modules.upscaler_utils] => <PIL.Image.Image image mode=RGB size=1024x1024 at 0x7FB310BB6D20> (scale factor 4)
tiled upscale (CPU Composite): 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 20/20 [00:00<00:00, 27.19it/s]
[Unload] Trying to free 7792.41 MB for cuda:0 with 1 models keep loaded ... Done.█████████████████████████████████████████████▍                 | 60/70 [00:26<00:03,  2.87it/s]
[Unload] Trying to free 7792.41 MB for cuda:0 with 1 models keep loaded ... Done.
[Unload] Trying to free 16850.56 MB for cuda:0 with 1 models keep loaded ... Done.
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:03<00:00,  2.86it/s]
[Unload] Trying to free 9511.87 MB for cuda:0 with 1 models keep loaded ... Done.███████████████████████████████████████████████████████████████| 70/70 [00:30<00:00,  2.63it/s]
Total progress: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 70/70 [00:31<00:00,  2.23it/s]
2025-11-19 22:45:19 INFO [modules.shared_state] Ending job Batch 2 out of 2 (32.32 seconds)█████████████████████████████████████████████████████| 70/70 [00:31<00:00,  2.63it/s]
```

Not any particular message related to the connection I think.

