### PR TITLE
add cmd_args for controlnet dirs and sanitize zero width spaces from prompt text from pnginfo

### DIFF
--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -76,6 +76,8 @@ parser.add_argument("--vae-dirs", type=normalized_filepath, action="append", hel
 parser.add_argument("--text-encoder-dirs", type=normalized_filepath, action="append", help="Directories for Text Encoder model(s)", default=[])
 parser.add_argument("--embeddings-dir", type=normalized_filepath, help="Directory for Textual Inversion model(s)", default=os.path.join(models_path, "embeddings"))
 parser.add_argument("--localizations-dir", type=normalized_filepath, help="Directory for localization file(s)", default=os.path.join(script_path, "localizations"))
+parser.add_argument("--controlnet-dir", type=normalized_filepath, help="Directory for ControlNet model(s)", default=[])
+parser.add_argument("--controlnet-preprocessor-models-dir", type=normalized_filepath, help="Path to directory with Annotator model(s)", default=[])
 
 parser.add_argument("--codeformer-models-path", type=normalized_filepath, help="Directory for CodeFormer model file(s)", default=os.path.join(models_path, "Codeformer"))
 parser.add_argument("--gfpgan-models-path", type=normalized_filepath, help="Directory for GFPGAN model file(s)", default=os.path.join(models_path, "GFPGAN"))

--- a/modules/images.py
+++ b/modules/images.py
@@ -829,6 +829,10 @@ def read_info_from_image(image: Image.Image) -> tuple[str | None, dict]:
             except Exception:
                 errors.report("Error parsing NovelAI image generation parameters", exc_info=True)
 
+        # sanitize zero-width spaces from prompt text if present
+        if '\u200b' in geninfo:
+            geninfo = geninfo.replace('\u200b','')
+
         return geninfo, items
 
     geninfo, items = read_standard()

--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -447,6 +447,8 @@ def configure_a1111_reference(a1111_home: Path):
         ModelRef(arg_name="--ckpt-dirs", relative_path="Stable-diffusion"),
         ModelRef(arg_name="--text-encoder-dirs", relative_path="text_encoder"),
         ModelRef(arg_name="--vae-dirs", relative_path="VAE"),
+        ModelRef(arg_name="--controlnet-dir", relative_path="ControlNet"),
+        ModelRef(arg_name="--controlnet-preprocessor-models-dir", relative_path="ControlNetPreprocessor"),
     )
 
     for ref in refs:


### PR DESCRIPTION
added cmd args for --controlnet-dir and --controlnet-preprocessor-models-dir and added autoconfig for them if --forge-ref-a1111-home is set