### PR TITLE
add option to append filename (without extension) to the prompt

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -111,14 +111,17 @@ def process_batch(p, input, output_dir, inpaint_mask_dir, args, to_scale=False, 
             except Exception:
                 parsed_parameters = {}
 
-            filename = ""
             if "Filename" in png_info_props:
-                filename = Path(image).stem
-                filename = filename.replace("(", "\\(").replace(")", "\\)").replace("_", " ")
-                filename = f"(, {filename}:1.5). "
-                print(f"Appending {filename} to the prompt.")
+                filename = image_path.stem
+                parsed_parameters["Filename"] = filename.replace("(", "\\(").replace(")", "\\)")
 
-            p.prompt = prompt + (" " + parsed_parameters["Prompt"] if "Prompt" in parsed_parameters else "") + filename
+            p.prompt = "".join(
+                [
+                    prompt,
+                    (" " + parsed_parameters["Prompt"] if "Prompt" in parsed_parameters else ""),
+                    (" " + parsed_parameters["Filename"] if "Filename" in parsed_parameters else ""),
+                ]
+            )
             p.negative_prompt = negative_prompt + (" " + parsed_parameters["Negative prompt"] if "Negative prompt" in parsed_parameters else "")
             p.seed = int(parsed_parameters.get("Seed", seed))
             p.cfg_scale = float(parsed_parameters.get("CFG scale", cfg_scale))

--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -111,7 +111,14 @@ def process_batch(p, input, output_dir, inpaint_mask_dir, args, to_scale=False, 
             except Exception:
                 parsed_parameters = {}
 
-            p.prompt = prompt + (" " + parsed_parameters["Prompt"] if "Prompt" in parsed_parameters else "")
+            filename = ""
+            if "Filename" in png_info_props:
+                filename = Path(image).stem
+                filename = filename.replace("(", "\\(").replace(")", "\\)").replace("_", " ")
+                filename = f"(, {filename}:1.5). "
+                print(f"Appending {filename} to the prompt.")
+
+            p.prompt = prompt + (" " + parsed_parameters["Prompt"] if "Prompt" in parsed_parameters else "") + filename
             p.negative_prompt = negative_prompt + (" " + parsed_parameters["Negative prompt"] if "Negative prompt" in parsed_parameters else "")
             p.seed = int(parsed_parameters.get("Seed", seed))
             p.cfg_scale = float(parsed_parameters.get("CFG scale", cfg_scale))

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -565,7 +565,7 @@ def create_ui():
                                 with gr.Accordion("PNG info", open=False):
                                     img2img_batch_use_png_info = gr.Checkbox(label="Append png info to prompts", elem_id="img2img_batch_use_png_info")
                                     img2img_batch_png_info_dir = gr.Textbox(label="PNG info directory", **shared.hide_dirs, placeholder="Leave empty to use input directory", elem_id="img2img_batch_png_info_dir")
-                                    img2img_batch_png_info_props = gr.CheckboxGroup(["Prompt", "Negative prompt", "Seed", "CFG scale", "Sampler", "Steps", "Model hash"], label="Parameters to take from png info", info="Prompts from png info will be appended to prompts set in ui.")
+                                    img2img_batch_png_info_props = gr.CheckboxGroup(["Prompt", "Negative prompt", "Seed", "CFG scale", "Sampler", "Steps", "Model hash", "Filename"], label="Parameters to take from png info", info="Prompts from png info will be appended to prompts set in ui.")
 
                             img2img_tabs = [tab_img2img, tab_sketch, tab_inpaint, tab_inpaint_color, tab_inpaint_upload, tab_batch]
 


### PR DESCRIPTION
Add option to append the filename (without extension) to the prompt.

<img width="1141" height="428" alt="image" src="https://github.com/user-attachments/assets/d3152b8e-5101-4cc5-a0ee-1709fd52d248" />
 