### PR TITLE
Add option to start Quicksettings Accordion closed

### DIFF
--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -445,7 +445,7 @@ options_templates.update(
             "paste_safe_guard": OptionInfo(False, 'Disable the "Read generation parameters" button (↙️) when negative prompt is not empty'),
             "ctrl_enter_interrupt": OptionInfo(False, "Revert [Ctrl + Enter] to only interrupt the generation").info('the current "intended" behavior is to interrupt the current generation then immediately start a new one'),
             "quicksettings_accordion": OptionInfo(False, "Place the Quicksettings under an Accordion").needs_reload_ui(),
-            "quicksettings_accordion_starts_closed": OptionInfo(False, "Quicksettings Accordion starts closed").info("Requires Place the Quicksettings under an Accordion").needs_reload_ui(),
+            "quicksettings_accordion_starts_closed": OptionInfo(False, "Close the Accordion on startup").info("for the above option").needs_reload_ui(),
             "quicksettings_style": OptionInfo("default", "Quicksettings Style", gr.Radio, {"choices": ("default", "clip-modules", "scrollbar")}).needs_reload_ui(),
             "qs_style_exp": OptionHTML(
                 """

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -445,6 +445,7 @@ options_templates.update(
             "paste_safe_guard": OptionInfo(False, 'Disable the "Read generation parameters" button (↙️) when negative prompt is not empty'),
             "ctrl_enter_interrupt": OptionInfo(False, "Revert [Ctrl + Enter] to only interrupt the generation").info('the current "intended" behavior is to interrupt the current generation then immediately start a new one'),
             "quicksettings_accordion": OptionInfo(False, "Place the Quicksettings under an Accordion").needs_reload_ui(),
+            "quicksettings_accordion_starts_closed": OptionInfo(False, "Quicksettings Accordion starts closed").info("Requires Place the Quicksettings under an Accordion").needs_reload_ui(),
             "quicksettings_style": OptionInfo("default", "Quicksettings Style", gr.Radio, {"choices": ("default", "clip-modules", "scrollbar")}).needs_reload_ui(),
             "qs_style_exp": OptionHTML(
                 """

--- a/modules/ui_settings.py
+++ b/modules/ui_settings.py
@@ -281,7 +281,8 @@ class UiSettings:
         self.interface = settings_interface
 
     def add_quicksettings(self):
-        with gr.Accordion(label="Quicksettings", open=True) if opts.quicksettings_accordion else nullcontext():
+        accordion_open = not getattr(opts, "quicksettings_accordion_starts_closed", False)
+        with gr.Accordion(label="Quicksettings", open=accordion_open) if opts.quicksettings_accordion else nullcontext():
             with gr.Row(elem_id="quicksettings", variant="compact", elem_classes=[opts.quicksettings_style]) as quicksettings_row:
                 main_entry.make_checkpoint_manager_ui()
                 for _i, k, _item in sorted(self.quicksettings_list, key=lambda x: self.quicksettings_names.get(x[1], x[0])):


### PR DESCRIPTION
Added a new option to start the Quicksettings Accordion in a closed state on startup.
Users who enable the Accordion feature typically want to maximize their screen space (myself included). While this option addresses that need, I kept the default behavior unchanged to accommodate users who prefer to adjust settings first before closing the accordion.

<img width="762" height="213" alt="image" src="https://github.com/user-attachments/assets/f0957873-dfb9-477d-b974-d680d694a33b" />

Note
I initially considered converting it to a checkbox-enabled accordion controlled by ui-config.json, but this approach resulted in a non-functional checkbox permanently displayed in the top-left corner of the screen, which would be poor UX. Therefore, I implemented this as a settings option instead.