### PR TITLE
Move NeverOOM options to System Settings for persistence

### DIFF
--- a/extensions-builtin/sd_forge_neveroom/scripts/forge_never_oom.py
+++ b/extensions-builtin/sd_forge_neveroom/scripts/forge_never_oom.py
@@ -1,6 +1,6 @@
 import gradio as gr
 
-from modules import scripts
+from modules import scripts, shared, script_callbacks
 from backend import memory_management
 
 
@@ -18,13 +18,11 @@ class NeverOOMForForge(scripts.Script):
         return scripts.AlwaysVisible
 
     def ui(self, *args, **kwargs):
-        with gr.Accordion(open=False, label=self.title()):
-            unet_enabled = gr.Checkbox(label='Enabled for UNet (always maximize offload)', value=False)
-            vae_enabled = gr.Checkbox(label='Enabled for VAE (always tiled)', value=False)
-        return unet_enabled, vae_enabled
+        return []
 
     def process(self, p, *script_args, **kwargs):
-        unet_enabled, vae_enabled = script_args
+        unet_enabled = getattr(shared.opts, "forge_never_oom_unet", False)
+        vae_enabled = getattr(shared.opts, "forge_never_oom_vae", False)
 
         if unet_enabled:
             print('NeverOOM Enabled for UNet (always maximize offload)')
@@ -45,3 +43,16 @@ class NeverOOMForForge(scripts.Script):
             self.previous_unet_enabled = unet_enabled
 
         return
+
+def on_ui_settings():
+    section = ('never_oom', "Never OOM")
+    shared.opts.add_option(
+        "forge_never_oom_unet",
+        shared.OptionInfo(False, "Enabled for UNet (always maximize offload)", section=section)
+    )
+    shared.opts.add_option(
+        "forge_never_oom_vae",
+        shared.OptionInfo(False, "Enabled for VAE (always tiled)", section=section)
+    )
+
+script_callbacks.on_ui_settings(on_ui_settings)


### PR DESCRIPTION
## Description
This PR moves the `Never OOM` extension options (UNet offload and VAE tiling) from the main txt2img/img2img accordion to the **Settings** tab.

## Motivation
Currently, users must manually enable `Never OOM` checkboxes every time the UI reloads or restarts. If a user forgets to check these boxes before generation, it often leads to an immediate OOM (Out of Memory) crash, requiring a full restart of the application.

By moving these options to `Shared Settings` (Settings -> Never OOM):
1. **Persistence:** Users can "set and forget." The configuration is saved in `config.json`.
2. **Safety:** Prevents accidental crashes caused by forgetting to toggle the option.
3. **Cleaner UI:** Removes unnecessary UI elements from the main interface since these settings are rarely toggled once configured for a specific machine.

## Changes
- Modified `forge_never_oom.py` to register options in `on_ui_settings`.
- Updated the script to read values from `shared.opts` instead of UI inputs.
- Removed the UI accordion from the main interface (`ui` method now returns `[]`).

Please consider merging this to improve the quality of life for low-VRAM users.