### PR TITLE
Support relative path for model loading in "modules/sd_models.py"

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -1,6 +1,6 @@
 import gc
 import math
-import os
+import os.path
 import re
 import sys
 
@@ -42,22 +42,20 @@ def replace_key(d, key, new_key, value):
 class CheckpointInfo:
     def __init__(self, filename):
         self.filename = filename
-        abspath = os.path.abspath(filename)
-        abs_ckpt_dirs = (*cmd_opts.ckpt_dirs, model_path)
+        abspath: str = os.path.abspath(filename)
+        abs_ckpt_dirs: list[str] = [os.path.abspath(_dir) for _dir in (*cmd_opts.ckpt_dirs, model_path)]
 
         self.is_safetensors = os.path.splitext(filename)[1].lower() == ".safetensors"
 
         # Initial fallback to prevent UnboundLocalError if no directory matches
-        name = os.path.basename(filename)
+        name: str = os.path.basename(filename)
         for _dir in abs_ckpt_dirs:
             # Ensure both paths are absolute for consistent string comparison, fixing issues with relative paths like ../
-            _dir_abs = os.path.abspath(str(_dir))
-            if abspath.startswith(_dir_abs):
-                name = abspath.replace(_dir_abs, "")
+            if abspath.startswith(_dir):
+                name = abspath.replace(_dir, "")
                 break
 
-        if name.startswith("\\") or name.startswith("/"):
-            name = name[1:]
+        name = name.strip("/").strip("\\")
 
         def read_metadata():
             metadata = read_metadata_from_safetensors(filename)

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -47,9 +47,13 @@ class CheckpointInfo:
 
         self.is_safetensors = os.path.splitext(filename)[1].lower() == ".safetensors"
 
+        # Initial fallback to prevent UnboundLocalError if no directory matches
+        name = os.path.basename(filename)
         for _dir in abs_ckpt_dirs:
-            if abspath.startswith(str(_dir)):
-                name = abspath.replace(str(_dir), "")
+            # Ensure both paths are absolute for consistent string comparison, fixing issues with relative paths like ../
+            _dir_abs = os.path.abspath(str(_dir))
+            if abspath.startswith(_dir_abs):
+                name = abspath.replace(_dir_abs, "")
                 break
 
         if name.startswith("\\") or name.startswith("/"):

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -47,9 +47,14 @@ class CheckpointInfo:
 
         self.is_safetensors = os.path.splitext(filename)[1].lower() == ".safetensors"
 
+        # Initialize name with basename as fallback (in case no directory matches)
+        name = os.path.basename(filename)
         for _dir in abs_ckpt_dirs:
-            if abspath.startswith(str(_dir)):
-                name = abspath.replace(str(_dir), "")
+            # Normalize both paths for comparison (handles mixed separators and case on Windows)
+            normalized_dir = os.path.normpath(os.path.abspath(str(_dir)))
+            normalized_abspath = os.path.normpath(abspath)
+            if normalized_abspath.startswith(normalized_dir):
+                name = normalized_abspath.replace(normalized_dir, "")
                 break
 
         if name.startswith("\\") or name.startswith("/"):


### PR DESCRIPTION
## Problem: 
Using a relative path for checkpoint files `--forge-ref-a1111-home ../stable-diffusion-webui) `caused:
`UnboundLocalError: cannot access local variable 'name' where it is not associated with a value`

## Cause: 
The variable 'name' was only set if the checkpoint path matched a directory in abs_ckpt_dirs. 
If no match occurred, 'name' remained undefined.

## Fix:
- Initialize 'name' with the basename of the file as fallback.
- Normalize paths to handle relative paths on Windows.

## Tested: 
Web UI starts and models load correctly with relative paths.
