### PR TITLE
Fix for OOM when switching models in XYZ plot with --cuda-stream > 0

### DIFF
--- a/backend/memory_management.py
+++ b/backend/memory_management.py
@@ -567,6 +567,11 @@ def minimum_inference_memory() -> float:
 
 
 def free_memory(memory_required: float, device: torch.device, keep_loaded: list["LoadedModel"] = []):
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+    elif torch.xpu.is_available():
+        torch.xpu.synchronize()
+
     cleanup_models_gc()
     unloaded_model = []
     can_unload = []

--- a/backend/sampling/sampling_function.py
+++ b/backend/sampling/sampling_function.py
@@ -401,9 +401,4 @@ def sampling_cleanup(unet: "UnetPatcher"):
     for cnet in unet.list_controlnets():
         cnet.cleanup()
 
-    if torch.cuda.is_available():
-        torch.cuda.synchronize()
-    elif torch.xpu.is_available():
-        torch.xpu.synchronize()
-
     memory_management.soft_empty_cache()

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -320,6 +320,8 @@ def forge_model_reload():
     timer = Timer()
 
     if model_data.sd_model is not None:
+        if memory_management.is_device_cuda(memory_management.get_torch_device()) and memory_management.NUM_STREAMS > 0:
+            torch.cuda.synchronize()
         model_data.sd_model = None
         model_data.forge_hash = ""
         memory_management.unload_all_models()

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -320,8 +320,6 @@ def forge_model_reload():
     timer = Timer()
 
     if model_data.sd_model is not None:
-        if memory_management.is_device_cuda(memory_management.get_torch_device()) and memory_management.NUM_STREAMS > 0:
-            torch.cuda.synchronize()
         model_data.sd_model = None
         model_data.forge_hash = ""
         memory_management.unload_all_models()


### PR DESCRIPTION
XYZ plots kept throwing OOM's when switching between 2 SVDQ models with `--cuda-stream` or `--cuda-stream 2`, perhaps other formats as well, didn't test. 

While `--cuda-stream 1` fixed this issue during XYZ plots, an OOM would still be thrown when the agent-scheduler plugin would start the next job immediately after the previous job.

This small addition fixes both issues by forcing a sync when switching models with `--cuda-stream > 0`.