### PR TITLE
Update audioop-lts dependency with version constraint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 GitPython==3.1.46
 Pillow==12.1.0
 accelerate==1.12.0
-audioop-lts==0.2.2
+audioop-lts==0.2.2; python_version >= "3.13"
 diffusers==0.36.0
 diskcache==5.6.3
 einops==0.8.2


### PR DESCRIPTION
Installing audioops-lts is only necessary due to audioops no longer built into python since 3.13 and it's making requirement installation fail on all python venv instance before 3.13

p/s: I can't update to 3.13 due to a1111 extension using legacy dependencies that have not been updated to 3.13 (e.g. mediapipe for adetailer)

```
RuntimeError: Couldn't install requirements.
Command: "G:\AIStuff\sd-webui-forge-neo\venv\Scripts\python.exe" -m pip install -r "requirements.txt" --prefer-binary
Error code: 1
stderr: Using Python 3.11.9 environment at: venv
  × No solution found when resolving dependencies:
  ╰─▶ Because the current Python version (3.11.9) does not satisfy
      Python>=3.13 and audioop-lts==0.2.2 depends on Python>=3.13, we can
      conclude that audioop-lts==0.2.2 cannot be used.
      And because you require audioop-lts==0.2.2, we can conclude that your
      requirements are unsatisfiable.
```