### PR TITLE
Fix formatting of audioop-lts dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 GitPython==3.1.46
 Pillow==12.1.0
 accelerate==1.12.0
-audioop-lts==0.2.2; python_version >= "3.13"
+audioop-lts==0.2.2;python_version>="3.13"
 diffusers==0.36.0
 diskcache==5.6.3
 einops==0.8.2


### PR DESCRIPTION
Removed spaces around the conditional in requirements.txt.

This should resolve issue with some environment not parsing the requirement file properly (whitespace is optional in PEP 508 but it did resolved https://github.com/Haoming02/sd-webui-forge-classic/issues/759 so 🤷)