### PR TITLE
Fix Flux2 TE attention mask alignment with Comfy

### DIFF
--- a/backend/nn/llm/llama.py
+++ b/backend/nn/llm/llama.py
@@ -385,11 +385,12 @@ class Llama2_(nn.Module):
         freqs_cis = precompute_freqs_cis(self.config.head_dim, position_ids, self.config.rope_theta, self.config.rope_scale, self.config.rope_dims, device=x.device)
 
         mask = None
+        mask_fill_value = torch.finfo(x.dtype).min / 4
         if attention_mask is not None:
             mask = 1.0 - attention_mask.to(x.dtype).reshape((attention_mask.shape[0], 1, -1, attention_mask.shape[-1])).expand(attention_mask.shape[0], 1, attention_mask.shape[-1], attention_mask.shape[-1])
-            mask = mask.masked_fill(mask.to(torch.bool), float("-inf"))
+            mask = mask.masked_fill(mask.to(torch.bool), mask_fill_value)
 
-        causal_mask = torch.empty(x.shape[1], x.shape[1], dtype=x.dtype, device=x.device).fill_(float("-inf")).triu_(1)
+        causal_mask = torch.empty(x.shape[1], x.shape[1], dtype=x.dtype, device=x.device).fill_(mask_fill_value).triu_(1)
         if mask is not None:
             mask += causal_mask
         else:

--- a/backend/text_processing/klein_engine.py
+++ b/backend/text_processing/klein_engine.py
@@ -112,6 +112,8 @@ class KleinTextProcessingEngine:
                 attention_mask.append(0 if eos else 1)
                 tokens_temp += [token]
                 if not eos and token == self.id_pad:
+                    # The first PAD token is masked out too (Comfy-compatible behavior).
+                    attention_mask[-1] = 0
                     eos = True
                 index += 1
 


### PR DESCRIPTION
This PR fixes an off-by-one error in Flux2 Klein text-encoder attention masking and aligns mask fill values with ComfyUI.

Changes:
- Mask out the first PAD token in ackend/text_processing/klein_engine.py (Comfy-compatible behavior).
- Use a finite attention/causal mask fill value (	orch.finfo(dtype).min / 4) in ackend/nn/llm/llama.py to match Comfy semantics.

Impact:
- Eliminates the extra unmasked PAD token that perturbs TE self-attention and amplifies downstream artifacts at higher resolutions.

Notes:
- Fix was validated by micro-dumps: attention mask now matches Comfy exactly and attention context divergence drops by orders of magnitude.