### PR TITLE
Flux2 TAESD: add compatibility path and remove BN dependency

### DIFF
--- a/backend/diffusion_engine/base.py
+++ b/backend/diffusion_engine/base.py
@@ -67,6 +67,7 @@ class ForgeDiffusionEngine:
         self.is_sd1 = False
         self.is_sdxl = False
         self.is_flux = False  # affects the usage of TAESD
+        self.is_flux2 = False  # affects the usage of TAESD
         self.is_wan = False  # affects the usage of WanVAE (B, C, T, H, W)
 
     @property

--- a/backend/diffusion_engine/flux2.py
+++ b/backend/diffusion_engine/flux2.py
@@ -22,6 +22,7 @@ class Flux2(ForgeDiffusionEngine):
     def __init__(self, estimated_config, huggingface_components):
         super().__init__(estimated_config, huggingface_components)
         self.is_inpaint = False
+        self.is_flux2 = True
 
         clip = CLIP(model_dict={"qwen3": huggingface_components["text_encoder"]}, tokenizer_dict={"qwen3": huggingface_components["tokenizer"]})
 

--- a/modules/sd_vae_taesd.py
+++ b/modules/sd_vae_taesd.py
@@ -52,7 +52,9 @@ class TAESDDecoder(nn.Module):
         super().__init__()
 
         if latent_channels is None:
-            if "taef1" in str(decoder_path):
+            if "taef2" in str(decoder_path):
+                latent_channels = 128
+            elif "taef1" in str(decoder_path):
                 latent_channels = 16
             else:
                 latent_channels = 4
@@ -69,7 +71,9 @@ class TAESDEncoder(nn.Module):
         super().__init__()
 
         if latent_channels is None:
-            if "taef1" in str(encoder_path):
+            if "taef2" in str(encoder_path):
+                latent_channels = 128
+            elif "taef1" in str(encoder_path):
                 latent_channels = 16
             else:
                 latent_channels = 4
@@ -87,7 +91,9 @@ def download_model(model_path, model_url):
 
 
 def decoder_model():
-    if shared.sd_model.is_flux:
+    if shared.sd_model.is_flux2:
+        model_name = "taef2_decoder.pth"
+    elif shared.sd_model.is_flux:
         model_name = "taef1_decoder.pth"
     elif shared.sd_model.is_sdxl:
         model_name = "taesdxl_decoder.pth"
@@ -114,7 +120,9 @@ def decoder_model():
 
 
 def encoder_model():
-    if shared.sd_model.is_flux:
+    if shared.sd_model.is_flux2:
+        model_name = "taef2_encoder.pth"
+    elif shared.sd_model.is_flux:
         model_name = "taef1_encoder.pth"
     elif shared.sd_model.is_sdxl:
         model_name = "taesdxl_encoder.pth"

--- a/modules/sd_vae_taesd.py
+++ b/modules/sd_vae_taesd.py
@@ -105,13 +105,6 @@ def guess_latent_channels_and_arch(path):
     return 4, None
 
 
-def _get_flux2_bn():
-    try:
-        return shared.sd_model.forge_objects.vae.first_stage_model.bn
-    except Exception:
-        return None
-
-
 def _pack_flux2_latents(x):
     b, c, h, w = x.shape
     if h % 2 != 0 or w % 2 != 0:
@@ -135,12 +128,6 @@ class Flux2DecoderAdapter(nn.Module):
 
     def forward(self, x):
         if x.shape[1] == 128:
-            bn = _get_flux2_bn()
-            if bn is not None:
-                s = torch.sqrt(bn.running_var.view(1, -1, 1, 1).to(device=x.device, dtype=x.dtype) + bn.eps)
-                m = bn.running_mean.view(1, -1, 1, 1).to(device=x.device, dtype=x.dtype)
-                x = x * s + m
-
             x = _unpack_flux2_latents(x)
 
         return self.decoder_impl(x)
@@ -156,15 +143,6 @@ class Flux2EncoderAdapter(nn.Module):
 
         if x.shape[1] == 32:
             x = _pack_flux2_latents(x)
-            bn = _get_flux2_bn()
-            if bn is not None:
-                x = torch.nn.functional.batch_norm(
-                    x,
-                    bn.running_mean.to(device=x.device, dtype=x.dtype),
-                    bn.running_var.to(device=x.device, dtype=x.dtype),
-                    momentum=bn.momentum,
-                    eps=bn.eps,
-                )
 
         return x
 

--- a/modules/sd_vae_taesd.py
+++ b/modules/sd_vae_taesd.py
@@ -26,40 +26,163 @@ class Clamp(nn.Module):
 
 
 class Block(nn.Module):
-    def __init__(self, n_in, n_out):
+    def __init__(self, n_in, n_out, use_midblock_gn=False):
         super().__init__()
         self.conv = nn.Sequential(conv(n_in, n_out), nn.ReLU(), conv(n_out, n_out), nn.ReLU(), conv(n_out, n_out))
         self.skip = nn.Conv2d(n_in, n_out, 1, bias=False) if n_in != n_out else nn.Identity()
         self.fuse = nn.ReLU()
+        self.pool = None
+
+        if use_midblock_gn:
+            conv1x1 = lambda c_in, c_out: nn.Conv2d(c_in, c_out, 1, bias=False)
+            n_gn = n_in * 4
+            self.pool = nn.Sequential(conv1x1(n_in, n_gn), nn.GroupNorm(4, n_gn), nn.ReLU(inplace=True), conv1x1(n_gn, n_in))
 
     def forward(self, x):
+        if self.pool is not None:
+            x = x + self.pool(x)
+
         return self.fuse(self.conv(x) + self.skip(x))
 
 
-def decoder(latent_channels=4):
-    return nn.Sequential(Clamp(), conv(latent_channels, 64), nn.ReLU(), Block(64, 64), Block(64, 64), Block(64, 64), nn.Upsample(scale_factor=2), conv(64, 64, bias=False), Block(64, 64), Block(64, 64), Block(64, 64), nn.Upsample(scale_factor=2), conv(64, 64, bias=False), Block(64, 64), Block(64, 64), Block(64, 64), nn.Upsample(scale_factor=2), conv(64, 64, bias=False), Block(64, 64), conv(64, 3))
+def decoder(latent_channels=4, use_midblock_gn=False):
+    mb_kw = {"use_midblock_gn": use_midblock_gn}
+
+    return nn.Sequential(
+        Clamp(),
+        conv(latent_channels, 64),
+        nn.ReLU(),
+        Block(64, 64, **mb_kw),
+        Block(64, 64, **mb_kw),
+        Block(64, 64, **mb_kw),
+        nn.Upsample(scale_factor=2),
+        conv(64, 64, bias=False),
+        Block(64, 64),
+        Block(64, 64),
+        Block(64, 64),
+        nn.Upsample(scale_factor=2),
+        conv(64, 64, bias=False),
+        Block(64, 64),
+        Block(64, 64),
+        Block(64, 64),
+        nn.Upsample(scale_factor=2),
+        conv(64, 64, bias=False),
+        Block(64, 64),
+        conv(64, 3),
+    )
 
 
-def encoder(latent_channels=4):
-    return nn.Sequential(conv(3, 64), Block(64, 64), conv(64, 64, stride=2, bias=False), Block(64, 64), Block(64, 64), Block(64, 64), conv(64, 64, stride=2, bias=False), Block(64, 64), Block(64, 64), Block(64, 64), conv(64, 64, stride=2, bias=False), Block(64, 64), Block(64, 64), Block(64, 64), conv(64, latent_channels))
+def encoder(latent_channels=4, use_midblock_gn=False):
+    mb_kw = {"use_midblock_gn": use_midblock_gn}
+
+    return nn.Sequential(
+        conv(3, 64),
+        Block(64, 64),
+        conv(64, 64, stride=2, bias=False),
+        Block(64, 64),
+        Block(64, 64),
+        Block(64, 64),
+        conv(64, 64, stride=2, bias=False),
+        Block(64, 64),
+        Block(64, 64),
+        Block(64, 64),
+        conv(64, 64, stride=2, bias=False),
+        Block(64, 64, **mb_kw),
+        Block(64, 64, **mb_kw),
+        Block(64, 64, **mb_kw),
+        conv(64, latent_channels),
+    )
+
+
+def guess_latent_channels_and_arch(path):
+    lower = str(path).lower()
+
+    if "taef2" in lower:
+        return 32, "flux_2"
+    if "taef1" in lower or "taesd3" in lower:
+        return 16, None
+
+    return 4, None
+
+
+def _get_flux2_bn():
+    try:
+        return shared.sd_model.forge_objects.vae.first_stage_model.bn
+    except Exception:
+        return None
+
+
+def _pack_flux2_latents(x):
+    b, c, h, w = x.shape
+    if h % 2 != 0 or w % 2 != 0:
+        return x
+
+    return x.view(b, c, h // 2, 2, w // 2, 2).permute(0, 1, 3, 5, 2, 4).reshape(b, c * 4, h // 2, w // 2)
+
+
+def _unpack_flux2_latents(x):
+    b, c, h, w = x.shape
+    if c % 4 != 0:
+        return x
+
+    return x.view(b, c // 4, 2, 2, h, w).permute(0, 1, 4, 2, 5, 3).reshape(b, c // 4, h * 2, w * 2)
+
+
+class Flux2DecoderAdapter(nn.Module):
+    def __init__(self, decoder_impl):
+        super().__init__()
+        self.decoder_impl = decoder_impl
+
+    def forward(self, x):
+        if x.shape[1] == 128:
+            bn = _get_flux2_bn()
+            if bn is not None:
+                s = torch.sqrt(bn.running_var.view(1, -1, 1, 1).to(device=x.device, dtype=x.dtype) + bn.eps)
+                m = bn.running_mean.view(1, -1, 1, 1).to(device=x.device, dtype=x.dtype)
+                x = x * s + m
+
+            x = _unpack_flux2_latents(x)
+
+        return self.decoder_impl(x)
+
+
+class Flux2EncoderAdapter(nn.Module):
+    def __init__(self, encoder_impl):
+        super().__init__()
+        self.encoder_impl = encoder_impl
+
+    def forward(self, x):
+        x = self.encoder_impl(x)
+
+        if x.shape[1] == 32:
+            x = _pack_flux2_latents(x)
+            bn = _get_flux2_bn()
+            if bn is not None:
+                x = torch.nn.functional.batch_norm(
+                    x,
+                    bn.running_mean.to(device=x.device, dtype=x.dtype),
+                    bn.running_var.to(device=x.device, dtype=x.dtype),
+                    momentum=bn.momentum,
+                    eps=bn.eps,
+                )
+
+        return x
 
 
 class TAESDDecoder(nn.Module):
     latent_magnitude = 3
     latent_shift = 0.5
 
-    def __init__(self, decoder_path="taesd_decoder.pth", latent_channels=None):
+    def __init__(self, decoder_path="taesd_decoder.pth", latent_channels=None, arch_variant=None):
         super().__init__()
 
         if latent_channels is None:
-            if "taef2" in str(decoder_path):
-                latent_channels = 128
-            elif "taef1" in str(decoder_path):
-                latent_channels = 16
-            else:
-                latent_channels = 4
+            latent_channels, guessed_arch = guess_latent_channels_and_arch(decoder_path)
+            if arch_variant is None:
+                arch_variant = guessed_arch
 
-        self.decoder = decoder(latent_channels)
+        self.decoder = decoder(latent_channels, use_midblock_gn=(arch_variant == "flux_2"))
+        self.decoder_api = Flux2DecoderAdapter(self.decoder) if arch_variant == "flux_2" else self.decoder
         self.decoder.load_state_dict(torch.load(decoder_path, map_location="cpu" if devices.device.type != "cuda" else None))
 
 
@@ -67,18 +190,16 @@ class TAESDEncoder(nn.Module):
     latent_magnitude = 3
     latent_shift = 0.5
 
-    def __init__(self, encoder_path="taesd_encoder.pth", latent_channels=None):
+    def __init__(self, encoder_path="taesd_encoder.pth", latent_channels=None, arch_variant=None):
         super().__init__()
 
         if latent_channels is None:
-            if "taef2" in str(encoder_path):
-                latent_channels = 128
-            elif "taef1" in str(encoder_path):
-                latent_channels = 16
-            else:
-                latent_channels = 4
+            latent_channels, guessed_arch = guess_latent_channels_and_arch(encoder_path)
+            if arch_variant is None:
+                arch_variant = guessed_arch
 
-        self.encoder = encoder(latent_channels)
+        self.encoder = encoder(latent_channels, use_midblock_gn=(arch_variant == "flux_2"))
+        self.encoder_api = Flux2EncoderAdapter(self.encoder) if arch_variant == "flux_2" else self.encoder
         self.encoder.load_state_dict(torch.load(encoder_path, map_location="cpu" if devices.device.type != "cuda" else None))
 
 
@@ -116,7 +237,7 @@ def decoder_model():
         else:
             raise FileNotFoundError("TAESD model not found...")
 
-    return loaded_model.decoder
+    return getattr(loaded_model, "decoder_api", loaded_model.decoder)
 
 
 def encoder_model():
@@ -145,4 +266,4 @@ def encoder_model():
         else:
             raise FileNotFoundError("TAESD model not found...")
 
-    return loaded_model.encoder
+    return getattr(loaded_model, "encoder_api", loaded_model.encoder)


### PR DESCRIPTION
## Summary
This PR adds Flux2 support to the TAESD path in `neo`.

## Changes
- add `is_flux2` compatibility flag in diffusion engine
- enable `is_flux2` in Flux2 engine
- add Flux2 (`taef2`) model routing in TAESD
- add Flux2 latent adapter path (pack/unpack)
- remove BN-dependent adapter logic (use no-BN path)

## Why no-BN
BN in the TAESD path caused oversaturation on the same latents.
The no-BN path matches full VAE brightness/contrast much more closely.

## Files
- `backend/diffusion_engine/base.py`
- `backend/diffusion_engine/flux2.py`
- `modules/sd_vae_taesd.py`