### PR TITLE
Use BFL Flux2 Automatic schedule for sigma generation

### DIFF
--- a/modules/sd_samplers_kdiffusion.py
+++ b/modules/sd_samplers_kdiffusion.py
@@ -1,4 +1,5 @@
 import inspect
+import math
 
 import k_diffusion
 import k_diffusion.external
@@ -47,6 +48,52 @@ k_diffusion_samplers_map = {x.name: x for x in samplers_data_k_diffusion}
 k_diffusion_scheduler = {x.name: x.function for x in sd_schedulers.schedulers}
 
 
+def compute_flux2_empirical_mu(image_seq_len: int, num_steps: int) -> float:
+    # Reference: black-forest-labs FLUX.2 sampling schedule.
+    a1, b1 = 8.73809524e-05, 1.89833333
+    a2, b2 = 0.00016927, 0.45666666
+
+    if image_seq_len > 4300:
+        return float(a2 * image_seq_len + b2)
+
+    m_200 = a2 * image_seq_len + b2
+    m_10 = a1 * image_seq_len + b1
+
+    a = (m_200 - m_10) / 190.0
+    b = m_200 - 200.0 * a
+    return float(a * num_steps + b)
+
+
+def get_flux2_image_seq_len(p) -> int:
+    sd_model = shared.sd_model
+    vae = getattr(getattr(sd_model, "forge_objects", None), "vae", None)
+    downscale_ratio = getattr(vae, "downscale_ratio", 16)
+
+    # Flux2 uses scalar downscale ratio (16). Fallback is 16 if unavailable.
+    if isinstance(downscale_ratio, (tuple, list)):
+        downscale_ratio = downscale_ratio[-1]
+
+    width = getattr(p, "width", 1024)
+    height = getattr(p, "height", 1024)
+
+    if getattr(p, "is_hr_pass", False):
+        width = getattr(p, "hr_resize_x", 0) or width
+        height = getattr(p, "hr_resize_y", 0) or height
+
+    latent_w = max(1, int(width) // int(downscale_ratio))
+    latent_h = max(1, int(height) // int(downscale_ratio))
+    return latent_w * latent_h
+
+
+def get_flux2_automatic_sigmas(num_steps: int, image_seq_len: int, device):
+    mu = compute_flux2_empirical_mu(image_seq_len=image_seq_len, num_steps=num_steps)
+    alpha = math.exp(mu)
+
+    # Equivalent to generalized_time_snr_shift(t, mu, 1.0) from BFL reference.
+    t = torch.linspace(1.0, 0.0, num_steps + 1, device=device, dtype=torch.float32)
+    return (alpha * t) / (1.0 + (alpha - 1.0) * t)
+
+
 class CFGDenoiserKDiffusion(sd_samplers_cfg_denoiser.CFGDenoiser):
     @property
     def inner_model(self):
@@ -89,7 +136,17 @@ class KDiffusionSampler(sd_samplers_common.Sampler):
         if p.sampler_noise_scheduler_override:
             sigmas = p.sampler_noise_scheduler_override(steps)
         elif scheduler is None or scheduler.function is None:
-            sigmas = self.model_wrap.get_sigmas(steps)
+            # Flux2 "Automatic" should follow BFL schedule construction.
+            if getattr(self.model_wrap.inner_model, "is_flux2", False):
+                image_seq_len = get_flux2_image_seq_len(p)
+                sigmas = get_flux2_automatic_sigmas(num_steps=steps, image_seq_len=image_seq_len, device=devices.cpu)
+                if not p.is_hr_pass:
+                    p.extra_generation_params["Schedule type"] = "Automatic (BFL)"
+                    p.extra_generation_params["Flux2 image seq len"] = image_seq_len
+                else:
+                    p.extra_generation_params["Hires schedule type"] = "Automatic (BFL)"
+            else:
+                sigmas = self.model_wrap.get_sigmas(steps)
         else:
             sigmas_kwargs = {"sigma_min": sigma_min, "sigma_max": sigma_max}
 


### PR DESCRIPTION
## Summary
This PR adds a Flux2-specific Automatic sigma schedule path based on BFL-style construction.

## Why
Current `origin/neo` does not include this sampler-side Flux2 Automatic schedule logic.
Commit `05a3680` updates Flux2 prediction, but does not add this `modules/sd_samplers_kdiffusion.py` schedule path.

## Changes
- add Flux2 empirical `mu` computation from image sequence length and step count
- add Flux2 Automatic sigma generation helper
- use this path in `KDiffusionSampler.get_sigmas()` when scheduler is Automatic and model is Flux2
- include schedule metadata in generation params (`Automatic (BFL)`)

## Files
- `modules/sd_samplers_kdiffusion.py`