### PR TITLE
feat: add ROCm Docker support for AMD GPUs (Linux)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+# Keep docker build context small (avoid models/outputs/caches)
+models/
+outputs/
+cache/
+tmp/
+output/
+__pycache__/
+
+# weights / binaries (very large)
+*.ckpt
+*.safetensors
+*.pt
+*.pth
+*.onnx
+*.bin
+
+# repo metadata / OS junk
+.git/
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM rocm/pytorch:rocm7.2_ubuntu24.04_py3.12_pytorch_release_2.9.1
+
+ENV DEBIAN_FRONTEND=noninteractive
+WORKDIR /workspace
+
+# Minimal runtime utilities + tini
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git \
+      ca-certificates \
+      curl \
+      tini \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---- Install Python requirements at BUILD time (fast boots) ----
+# We only copy the requirement file(s) needed for dependency install,
+# NOT the full repo (models/etc stay on host via bind mount).
+COPY requirements.txt /tmp/requirements.txt
+
+RUN python -m pip install --upgrade pip \
+ && pip install --no-cache-dir -r /tmp/requirements.txt
+
+# Copy entrypoint (small, stable)
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 7860
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  forge-rocm:
+    build:
+      context: .
+      dockerfile: Dockerfile
+
+    container_name: forge-rocm
+    restart: unless-stopped
+
+    ports:
+      - "7860:7860"   # Change left side if you want a different host port
+
+    devices:
+      - /dev/kfd:/dev/kfd
+      - /dev/dri:/dev/dri
+
+    group_add:
+      - video
+      - render
+
+    volumes:
+      - ./:/workspace
+
+    environment:
+      FORGE_HOST: "0.0.0.0"
+      FORGE_ARGS: >-
+        --api
+        --enable-insecure-extension-access
+        --skip-python-version-check
+        --skip-version-check
+        --disable-xformers
+        --skip-torch-cuda-test
+
+    shm_size: "8gb"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FORGE_HOST="${FORGE_HOST:-0.0.0.0}"
+FORGE_ARGS="${FORGE_ARGS:-}"
+
+cd /workspace
+
+read -r -a EXTRA_ARGS <<< "${FORGE_ARGS}"
+
+exec python3 launch.py \
+  --listen "${FORGE_HOST}" \
+  --port 7860 \
+  "${EXTRA_ARGS[@]}"


### PR DESCRIPTION
Adds Docker + docker-compose support for running sd-webui-forge-classic
with ROCm (AMD GPUs) on Linux.

### Details
- Based on `rocm/pytorch`
- Installs Python requirements at build time (fast container startup)
- Bind-mounts repository so models/outputs remain on host
- Exposes launch flags via `FORGE_ARGS` in docker-compose
- Maps `/dev/kfd` and `/dev/dri` and adds `video`/`render` groups
- Compatible with Docker and Podman

### Tested on
- Arch Linux
- RX 7800 XT
- ROCm 7.2