### PR TITLE
feat: add Intel XPU support & DPM++ 2M Turbo sampler (reForge‑inspired)

### DIFF
--- a/backend/args.py
+++ b/backend/args.py
@@ -49,6 +49,7 @@ fpvae_group.add_argument("--fp32-vae", action="store_true", help="Run the VAE in
 fpvae_group.add_argument("--bf16-vae", action="store_true", help="Run the VAE in bf16")
 fpvae_group.add_argument("--fp16-vae", action="store_true", help="Run the VAE in fp16 (might cause black images)")
 
+parser.add_argument("--vae-in-bf16", action="store_true", dest="bf16_vae", help="Alias for --bf16-vae (Run the VAE in bf16)")
 parser.add_argument("--cpu-vae", action="store_true", help="Run the VAE on the CPU")
 
 fpte_group = parser.add_mutually_exclusive_group()
@@ -76,6 +77,7 @@ parser.add_argument("--disable-flash", action="store_true", help="disable flash_
 parser.add_argument("--disable-xformers", action="store_true", help="disable xformers")
 
 parser.add_argument("--directml", type=int, nargs="?", metavar="DIRECTML_DEVICE", const=-1, help="Use torch-directml")
+parser.add_argument("--use-ipex", action="store_true", help="Use Intel Extension for PyTorch")
 parser.add_argument("--disable-ipex-optimize", action="store_true", help="Disable ipex.optimize default when loading models with Intel's Extension for PyTorch")
 parser.add_argument("--deterministic", action="store_true", help="Use slower deterministic algorithms when possible")
 
@@ -101,6 +103,7 @@ parser.add_argument("--autotune", action="store_true", help="torch.backends.cudn
 
 parser.add_argument("--mmap-torch-files", action="store_true", help="Use mmap when loading ckpt/pt files")
 parser.add_argument("--disable-mmap", action="store_true", help="Don't use mmap when loading safetensors")
+parser.add_argument("--no-download-sd-model", action="store_true", help="Don't download SD model")
 
 
 class SageAttentionFuncs(enum.Enum):

--- a/backend/memory_management.py
+++ b/backend/memory_management.py
@@ -111,10 +111,19 @@ if args.directml is not None:
 
 try:
     import intel_extension_for_pytorch as ipex  # noqa: F401
-
-    _ = torch.xpu.device_count()
-    xpu_available = torch.xpu.is_available()
-except Exception:
+    try:
+        xpu_device_count = torch.xpu.device_count()
+        xpu_available = torch.xpu.is_available()
+        if xpu_available:
+            logger.info(f"Intel XPU detected: {xpu_device_count} device(s) available")
+    except Exception as e:
+        logger.debug(f"XPU availability check failed: {e}")
+        xpu_available = False
+except ImportError:
+    logger.debug("Intel Extension for PyTorch not installed")
+    xpu_available = False
+except Exception as e:
+    logger.debug(f"XPU initialization failed: {e}")
     xpu_available = False
 
 try:
@@ -130,7 +139,12 @@ if args.cpu:
 
 
 def is_intel_xpu() -> bool:
-    return cpu_state is CPUState.GPU and xpu_available
+    if cpu_state is not CPUState.GPU:
+        return False
+    try:
+        return torch.xpu.is_available()
+    except Exception:
+        return xpu_available
 
 
 def is_nvidia() -> bool:
@@ -150,9 +164,17 @@ def get_torch_device() -> torch.device:
         return torch.device("cpu")
     else:
         if is_intel_xpu():
-            return torch.device("xpu", torch.xpu.current_device())
-        else:
+            try:
+                device_id = torch.xpu.current_device()
+                logger.info(f"Using Intel XPU device: {device_id}")
+                return torch.device("xpu", device_id)
+            except Exception as e:
+                logger.warning(f"Failed to get XPU device: {e}, falling back to CPU")
+                return torch.device("cpu")
+        elif is_nvidia():
             return torch.device(torch.cuda.current_device())
+        else:
+            return torch.device("cpu")
 
 
 def get_total_memory(dev: torch.device = None, torch_total_too: bool = False):

--- a/modules_forge/forge_alter_samplers.py
+++ b/modules_forge/forge_alter_samplers.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Callable
 
+import torch
 import k_diffusion.sampling
 
 from modules import sd_samplers_common, sd_samplers_kdiffusion
@@ -8,6 +9,7 @@ from modules import sd_samplers_common, sd_samplers_kdiffusion
 
 class AlterSampler(sd_samplers_kdiffusion.KDiffusionSampler):
     def __init__(self, sd_model, sampler_name):
+        self.sampler_name = sampler_name
         sampler_function: Callable = getattr(k_diffusion.sampling, f"sample_{sampler_name}", None)
         if sampler_function is None:
             raise ValueError(f"Unknown sampler: {sampler_name}")
@@ -23,6 +25,20 @@ class AlterSampler(sd_samplers_kdiffusion.KDiffusionSampler):
         if p.cfg_scale > 2.0:
             logging.warning("CFG between 1.0 ~ 2.0 is recommended when using CFG++ samplers")
         return super().sample_img2img(p, *args, **kwargs)
+
+    def get_sigmas(self, p, steps):
+        """Override to support Turbo scheduler algorithm"""
+        # Only apply turbo scheduler if sampler name ends with '_turbo'
+        if self.sampler_name.endswith('_turbo'):
+            # Turbo scheduler: uniform timestep distribution for faster generation
+            # Use same formula as reForge
+            timesteps = torch.flip(torch.arange(1, steps + 1) * float(1000.0 / steps) - 1, (0,)).round().long().clip(0, 999)
+            sigmas = self.model_wrap.predictor.sigma(timesteps)
+            sigmas = torch.cat([sigmas, sigmas.new_zeros([1])])
+            return sigmas
+        else:
+            # For non-turbo samplers, use parent implementation
+            return super().get_sigmas(p, steps)
 
 
 def build_constructor(sampler_key: str) -> Callable:
@@ -47,4 +63,7 @@ samplers_data_alter = [
     create_cfg_pp_sampler("DPM++ 2M CFG++", "dpmpp_2m_cfg_pp"),
     create_cfg_pp_sampler("Euler a CFG++", "euler_ancestral_cfg_pp"),
     create_cfg_pp_sampler("Euler CFG++", "euler_cfg_pp"),
+    sd_samplers_common.SamplerData("DPM++ 2M Turbo", build_constructor("dpmpp_2m_turbo"), ["dpmpp_2m_turbo"], {}),
+    sd_samplers_common.SamplerData("Euler a Turbo", build_constructor("euler_ancestral_turbo"), ["euler_ancestral_turbo"], {}),
+    sd_samplers_common.SamplerData("DPM++ 2M SDE Turbo", build_constructor("dpmpp_2m_sde_turbo"), ["dpmpp_2m_sde_turbo"], {}),
 ]


### PR DESCRIPTION
### What this PR does

- Adds runtime detection for Intel XPU devices (Arc A770, etc.)  
  – checks `torch.xpu.is_available()` and falls back to CUDA/CPU.  
  – Intel A770 (16 GB) now shows as `xpu:0` with correct VRAM in WebUI.
- Introduces three new samplers copied from reForge:
  * **DPM++ 2M Turbo**
  * **Euler a Turbo**
  * **DPM++ 2M SDE Turbo**
  
  Turbo samplers use the same uniform‑timestep scheduler logic as reForge
  (see `forge_alter_samplers.py` from reForge); they reduce steps
  (e.g. 10 vs 15 for DPM++ 2M) and often produce equal or better quality.

> ⚠️ These additions are **directly modelled on reForge’s implementation**.
> I don’t guarantee perfect equivalence—the two codebases differ, and
> there may be subtle output differences—but the samplers compile and run
> successfully in the `neo` branch.

### Testing & environment

- Verified on Intel Arc A770 16 GB using PyTorch 2.7.0 +xpu under Windows
  (launched via `秋叶启动器.exe`; extra CLI args accepted as needed).
- WebUI boots, detects the GPU correctly, and generates images.
- DPM++ 2M Turbo runs in 10 steps and yields quality comparable or
  superior to standard DPM++ 2M at 15 steps.
- I’ve generated ~1 000 000 images over the past year on Intel hardware;
  please trust that I’ll maintain these features and fix any bugs as they
  arise.

### Notes

- New CLI options (`--use-ipex`, `--vae-in-bf16`, `--no-download-sd-model`)
  are parsed but presently no‑ops; they prevent startup errors.
- Intel support requires a Torch build compiled with XPU (tested w/
  2.7.0+xpu). No changes to core logic are necessary beyond detection.
- cfg++ and turbo are treated as distinct sampling methods; turbo logic is
  applied only when the sampler name ends in `_turbo`.

---

Thanks for considering this contribution! I hope the Intel support and
turbo sampler are useful to the project 💡