### PR TITLE
Expand torch.compile built in extension with more presets and advanced options.

### DIFF
--- a/extensions-builtin/sd_forge_compile/scripts/compile.py
+++ b/extensions-builtin/sd_forge_compile/scripts/compile.py
@@ -92,13 +92,13 @@ so no mode options are lost.
                     """
                 )
                 dynamic                   = gr.Checkbox(label="dynamic shapes — support any resolution/batch size (overrides preset default)", value=False)
+                max_autotune_pointwise    = gr.Checkbox(label="max_autotune_pointwise",    value=False)
+                max_autotune_gemm         = gr.Checkbox(label="max_autotune_gemm",         value=False)
                 epilogue_fusion           = gr.Checkbox(label="epilogue_fusion",           value=False)
                 shape_padding             = gr.Checkbox(label="shape_padding",             value=False)
                 fallback_random           = gr.Checkbox(label="fallback_random",           value=False)
                 triton_cudagraphs         = gr.Checkbox(label="triton.cudagraphs",         value=False)
                 coordinate_descent_tuning = gr.Checkbox(label="coordinate_descent_tuning", value=False)
-                max_autotune_pointwise    = gr.Checkbox(label="max_autotune_pointwise",    value=False)
-                max_autotune_gemm         = gr.Checkbox(label="max_autotune_gemm",         value=False)
 
         return [
             preset,

--- a/extensions-builtin/sd_forge_compile/scripts/compile.py
+++ b/extensions-builtin/sd_forge_compile/scripts/compile.py
@@ -81,7 +81,7 @@ When combined with a mode-based preset (`max-autotune`, `max-autotune-no-cudagra
 the mode is first expanded to its exact base options and then your selections are merged on top —
 so no mode options are lost.
 
-- **dynamic shapes:** Override the preset's dynamic setting — allows any resolution/batch size at the cost of longer compile. Note: incompatible with `triton.cudagraphs` and CUDA-graph-based presets
+- **dynamic shapes:** Allows any resolution/batch size at the cost of longer compile. Note: incompatible with `triton.cudagraphs` and CUDA-graph-based presets. Always enabled despite box selection if using dynamic preset.
 - **max_autotune_pointwise:** Autotune pointwise/reduction kernels independently (subset of `max_autotune`)
 - **max_autotune_gemm:** Autotune GEMM kernels independently (subset of `max_autotune`)
 - **epilogue_fusion:** Fuse pointwise ops into the preceding kernel — requires `max_autotune` or `max_autotune_gemm`
@@ -91,7 +91,7 @@ so no mode options are lost.
 - **coordinate_descent_tuning:** Tune tile configs via coordinate descent — included in both max-autotune modes, expose here for other presets
                     """
                 )
-                dynamic                   = gr.Checkbox(label="dynamic shapes — support any resolution/batch size (overrides preset default)", value=False)
+                dynamic                   = gr.Checkbox(label="dynamic shapes — support any resolution/batch size.", value=False)
                 max_autotune_pointwise    = gr.Checkbox(label="max_autotune_pointwise",    value=False)
                 max_autotune_gemm         = gr.Checkbox(label="max_autotune_gemm",         value=False)
                 epilogue_fusion           = gr.Checkbox(label="epilogue_fusion",           value=False)

--- a/extensions-builtin/sd_forge_compile/scripts/compile.py
+++ b/extensions-builtin/sd_forge_compile/scripts/compile.py
@@ -81,7 +81,7 @@ When combined with a mode-based preset (`max-autotune`, `max-autotune-no-cudagra
 the mode is first expanded to its exact base options and then your selections are merged on top —
 so no mode options are lost.
 
-- **dynamic shapes:** Allows any resolution/batch size at the cost of longer compile. Note: incompatible with `triton.cudagraphs` and CUDA-graph-based presets. Always enabled if using dynamic or max-autotune-no-cudagraphs preset despite box selection.
+- **dynamic shapes:** Allows any resolution/batch size at the cost of longer compile. Note: incompatible with `triton.cudagraphs` and CUDA-graph-based presets. Default Auto.
 - **max_autotune_pointwise:** Autotune pointwise/reduction kernels independently (subset of `max_autotune`)
 - **max_autotune_gemm:** Autotune GEMM kernels independently (subset of `max_autotune`)
 - **epilogue_fusion:** Fuse pointwise ops into the preceding kernel — requires `max_autotune` or `max_autotune_gemm`
@@ -91,7 +91,7 @@ so no mode options are lost.
 - **coordinate_descent_tuning:** Tune tile configs via coordinate descent — included in both max-autotune modes, expose here for other presets
                     """
                 )
-                dynamic                   = gr.Checkbox(label="dynamic shapes — support any resolution/batch size.", value=False)
+                dynamic = gr.Radio(label="dynamic shapes", value="Auto",choices=["Auto", "Enabled", "Disabled"], info="Override the preset's dynamic setting. Auto = use preset default.",)
                 max_autotune_pointwise    = gr.Checkbox(label="max_autotune_pointwise",    value=False)
                 max_autotune_gemm         = gr.Checkbox(label="max_autotune_gemm",         value=False)
                 epilogue_fusion           = gr.Checkbox(label="epilogue_fusion",           value=False)
@@ -170,8 +170,8 @@ so no mode options are lost.
             case _:
                 config: dict = kmodel._compile_config
  
-        if dynamic and config.get("backend") == "inductor":
-            config["dynamic"] = True
+        if dynamic != "Auto" and config.get("backend") == "inductor":
+            config["dynamic"] = (dynamic == "Enabled")
 
         if config.get("backend") == "inductor":
             extra_options = {}

--- a/extensions-builtin/sd_forge_compile/scripts/compile.py
+++ b/extensions-builtin/sd_forge_compile/scripts/compile.py
@@ -9,6 +9,22 @@ import torch
 from backend.utils import get_attr, set_attr_raw
 from modules import scripts
 
+# Base options for inductor modes, to then add advanced options alongside these. These come directly from torch._inductor.config.
+_MODE_BASE_OPTIONS: dict[str, dict] = {
+    "max-autotune": {
+        "coordinate_descent_tuning": True,
+        "max_autotune": True,
+        "triton.cudagraphs": True,
+    },
+    "max-autotune-no-cudagraphs": {
+        "coordinate_descent_tuning": True,
+        "max_autotune": True,
+    },
+    "reduce-overhead": {
+        "triton.cudagraphs": True,
+    },
+}
+
 
 def skip_torch_compile_dict(guard_entries):
     # https://github.com/Comfy-Org/ComfyUI/blob/master/comfy_extras/nodes_torch_compile.py#L5
@@ -20,6 +36,7 @@ class TorchCompileForForge(scripts.Script):
 
     def __init__(self):
         torch._dynamo.config.cache_size_limit = 256
+        torch._dynamo.config.suppress_errors = True
 
     def title(self):
         return "Torch Compile Integrated"
@@ -31,20 +48,69 @@ class TorchCompileForForge(scripts.Script):
         with gr.Accordion(open=False, label=self.title()):
             gr.Markdown(
                 """
-**torch.compile** speeds up the Inference by compiling the model ahead of time
-- **guard_filter_fn:** Compile the Fastest ; Require recompilation if Resolution / Batch Size is changed
-- **dynamic:** Longer to Compile ; Support any Resolution / Batch Size
-- **cudagraphs:** Not Recommended
+**torch.compile** speeds up the Inference by compiling the model ahead of time.
+- **guard_filter_fn:** Compile the Fastest ; Require recompilation if Resolution / Batch Size is changed.
+- **dynamic:** Longer to Compile ; Support any Resolution / Batch Size.
+- **max-autotune:** CUDA graphs + coordinate_descent_tuning — best runtime speed, doesn't work with CUDA Malloc. Require recompilation if Resolution / Batch Size is changed.
+- **max-autotune-no-cudagraphs:** Triton autotuned kernels + coordinate descent tuning, no CUDA graphs. Faster than dynamic but takes longer to compile. Support any Resolution / Batch Size.
+- **reduce-overhead:** CUDA graphs via inductor, lower compile cost than max-autotune. Doesn't work with CUDA Malloc. Require recompilation if Resolution / Batch Size is changed.
+- **cudagraphs:** Not Recommended. Doesn't work with CUDA Malloc.
                 """
             )
             preset = gr.Dropdown(
                 label="Preset",
                 value="Automatic",
-                choices=["Automatic", "Disable", "guard_filter_fn", "dynamic", "cudagraphs"],
+                choices=[
+                    "Automatic",
+                    "Disable",
+                    "guard_filter_fn",
+                    "dynamic",
+                    "max-autotune-no-cudagraphs",
+                    "max-autotune",
+                    "reduce-overhead",
+                    "cudagraphs",
+                ],
                 info='"Automatic" maintains the current compile status',
             )
 
-        return [preset]
+            with gr.Accordion(open=False, label="Advanced Options"):
+                gr.Markdown(
+                    """
+These options are layered on top of the selected preset (inductor backend only, so it doesn't apply on cudagraphs).
+When combined with a mode-based preset (`max-autotune`, `max-autotune-no-cudagraphs`, `reduce-overhead`),
+the mode is first expanded to its exact base options and then your selections are merged on top —
+so no mode options are lost.
+
+- **dynamic shapes:** Override the preset's dynamic setting — allows any resolution/batch size at the cost of longer compile. Note: incompatible with `triton.cudagraphs` and CUDA-graph-based presets
+- **max_autotune_pointwise:** Autotune pointwise/reduction kernels independently (subset of `max_autotune`)
+- **max_autotune_gemm:** Autotune GEMM kernels independently (subset of `max_autotune`)
+- **epilogue_fusion:** Fuse pointwise ops into the preceding kernel — requires `max_autotune` or `max_autotune_gemm`
+- **shape_padding:** Pad tensor shapes to powers of 2 for better kernel alignment
+- **fallback_random:** Allow graph fallback for random ops (improves capture rate)
+- **triton.cudagraphs:** Enable CUDA graphs within inductor (distinct from the `cudagraphs` backend preset)
+- **coordinate_descent_tuning:** Tune tile configs via coordinate descent — included in both max-autotune modes, expose here for other presets
+                    """
+                )
+                dynamic                   = gr.Checkbox(label="dynamic shapes — support any resolution/batch size (overrides preset default)", value=False)
+                epilogue_fusion           = gr.Checkbox(label="epilogue_fusion",           value=False)
+                shape_padding             = gr.Checkbox(label="shape_padding",             value=False)
+                fallback_random           = gr.Checkbox(label="fallback_random",           value=False)
+                triton_cudagraphs         = gr.Checkbox(label="triton.cudagraphs",         value=False)
+                coordinate_descent_tuning = gr.Checkbox(label="coordinate_descent_tuning", value=False)
+                max_autotune_pointwise    = gr.Checkbox(label="max_autotune_pointwise",    value=False)
+                max_autotune_gemm         = gr.Checkbox(label="max_autotune_gemm",         value=False)
+
+        return [
+            preset,
+            dynamic,
+            epilogue_fusion,
+            shape_padding,
+            fallback_random,
+            triton_cudagraphs,
+            coordinate_descent_tuning,
+            max_autotune_pointwise,
+            max_autotune_gemm,
+        ]
 
     @staticmethod
     def restore(kmodel: "KModel"):
@@ -65,7 +131,20 @@ class TorchCompileForForge(scripts.Script):
         model = get_attr(kmodel, "_model_backup")
         set_attr_raw(kmodel, "diffusion_model", model)
 
-    def process_batch(self, p, preset: str, **kwargs):
+    def process_batch(
+        self,
+        p,
+        preset: str,
+        dynamic: bool,
+        epilogue_fusion: bool,
+        shape_padding: bool,
+        fallback_random: bool,
+        triton_cudagraphs: bool,
+        coordinate_descent_tuning: bool,
+        max_autotune_pointwise: bool,
+        max_autotune_gemm: bool,
+        **kwargs,
+    ):
         kmodel: "KModel" = p.sd_model.forge_objects.unet.model
         compiled: bool = hasattr(kmodel, "_compile_config")
         enable: bool = compiled if preset == "Automatic" else (preset != "Disable")
@@ -80,10 +159,38 @@ class TorchCompileForForge(scripts.Script):
                 config = dict(backend="inductor", dynamic=False, fullgraph=False, options={"guard_filter_fn": skip_torch_compile_dict})
             case "dynamic":
                 config = dict(backend="inductor", dynamic=True, fullgraph=False)
+            case "max-autotune-no-cudagraphs":
+                config = dict(backend="inductor", mode="max-autotune-no-cudagraphs", dynamic=True, fullgraph=False)
+            case "max-autotune":
+                config = dict(backend="inductor", mode="max-autotune", dynamic=False, fullgraph=False)
+            case "reduce-overhead":
+                config = dict(backend="inductor", mode="reduce-overhead", dynamic=False, fullgraph=False)
             case "cudagraphs":
                 config = dict(backend="cudagraphs", dynamic=True, fullgraph=True)
             case _:
                 config: dict = kmodel._compile_config
+ 
+        if dynamic and config.get("backend") == "inductor":
+            config["dynamic"] = True
+
+        if config.get("backend") == "inductor":
+            extra_options = {}
+            if epilogue_fusion:            extra_options["epilogue_fusion"]           = True
+            if shape_padding:              extra_options["shape_padding"]             = True
+            if fallback_random:            extra_options["fallback_random"]           = True
+            if triton_cudagraphs:          extra_options["triton.cudagraphs"]         = True
+            if coordinate_descent_tuning:  extra_options["coordinate_descent_tuning"] = True
+            if max_autotune_pointwise:     extra_options["max_autotune_pointwise"]    = True
+            if max_autotune_gemm:          extra_options["max_autotune_gemm"]         = True
+
+            if extra_options:
+                # torch.compile forbids mode + options together.
+                # Pop the mode key and seed base with its exact known expansion
+                # then merge the user's checkboxes on top — user values win on conflict.
+                mode = config.pop("mode", None)
+                base = _MODE_BASE_OPTIONS.get(mode, {}).copy() if mode else {}
+                base.update(extra_options)
+                config.setdefault("options", {}).update(base)
 
         if compiled:
             if kmodel._compile_config == config:

--- a/extensions-builtin/sd_forge_compile/scripts/compile.py
+++ b/extensions-builtin/sd_forge_compile/scripts/compile.py
@@ -81,7 +81,7 @@ When combined with a mode-based preset (`max-autotune`, `max-autotune-no-cudagra
 the mode is first expanded to its exact base options and then your selections are merged on top —
 so no mode options are lost.
 
-- **dynamic shapes:** Allows any resolution/batch size at the cost of longer compile. Note: incompatible with `triton.cudagraphs` and CUDA-graph-based presets. Always enabled despite box selection if using dynamic preset.
+- **dynamic shapes:** Allows any resolution/batch size at the cost of longer compile. Note: incompatible with `triton.cudagraphs` and CUDA-graph-based presets. Always enabled if using dynamic preset despite box selection.
 - **max_autotune_pointwise:** Autotune pointwise/reduction kernels independently (subset of `max_autotune`)
 - **max_autotune_gemm:** Autotune GEMM kernels independently (subset of `max_autotune`)
 - **epilogue_fusion:** Fuse pointwise ops into the preceding kernel — requires `max_autotune` or `max_autotune_gemm`

--- a/extensions-builtin/sd_forge_compile/scripts/compile.py
+++ b/extensions-builtin/sd_forge_compile/scripts/compile.py
@@ -81,7 +81,7 @@ When combined with a mode-based preset (`max-autotune`, `max-autotune-no-cudagra
 the mode is first expanded to its exact base options and then your selections are merged on top —
 so no mode options are lost.
 
-- **dynamic shapes:** Allows any resolution/batch size at the cost of longer compile. Note: incompatible with `triton.cudagraphs` and CUDA-graph-based presets. Always enabled if using dynamic preset despite box selection.
+- **dynamic shapes:** Allows any resolution/batch size at the cost of longer compile. Note: incompatible with `triton.cudagraphs` and CUDA-graph-based presets. Always enabled if using dynamic or max-autotune-no-cudagraphs preset despite box selection.
 - **max_autotune_pointwise:** Autotune pointwise/reduction kernels independently (subset of `max_autotune`)
 - **max_autotune_gemm:** Autotune GEMM kernels independently (subset of `max_autotune`)
 - **epilogue_fusion:** Fuse pointwise ops into the preceding kernel — requires `max_autotune` or `max_autotune_gemm`


### PR DESCRIPTION
Hello, thanks for your great work on torch.compile, works perfectly!

I wanted to add some presets and more options, so it can be more configurable. Like faster but longer time to compile, or import shape padding, etc.

I have added as new options:

- max-autotune: Faster torch compile option for inference, that uses cudagraphs, max autotune and coordinate_descent_tuning. Cons: It takes longer to compile, doesn't support cuda malloc, doesn't support dynamic (so if resolution or batch size is changed, it has to recompile).
- max-autotune-no-cudagraphs: Second fastest torch compile for inference, that doesn't uses cudagraphs, while being faster than dynamic preset and supports resolution-batch size change. Cons: Take longer to compile vs dynamic.
- reduce-overhead: Faster compilation mode like guard_filter, but using cuda graphs. Cons: Same as max-autotune.

And then, also added new advanced options which you can test:

- dynamic: Basically dynamic shapes, so it makes the mode support resolution/batch size change without recompiling. Note that this isn't supported on models that use cudagraphs.
- max_autotune_pointwise: Autotune pointwise/reduction kernels independently
- max_autotune_gemm: Autotune GEMM kernels independently
- epilogue_fusion: Fuse pointwise ops into the preceding kernel
- shape_padding: Pad tensor shapes to powers of 2 for better kernel alignment
- fallback_random: Allow graph fallback for random ops
- triton.cudagraphs: Enable CUDA graphs within inductor (distinct from the `cudagraphs` backend preset)
- coordinate_descent_tuning: Tune tile configs via coordinate descent

<img width="1831" height="468" alt="imagen" src="https://github.com/user-attachments/assets/423d8249-b1a8-461e-b426-7ea3c9ef81e9" />

<img width="1827" height="220" alt="imagen" src="https://github.com/user-attachments/assets/39f6068d-fa20-4427-b0b4-2ed68cc06552" />

<img width="1811" height="896" alt="imagen" src="https://github.com/user-attachments/assets/e4ce75d8-fb1f-4dce-ad51-0376f898a499" />

I have tested all configurations on XL, SDXL RF and Anima without issues so far, but I haven't tested i.e. on video models and such.

A but is that when using max autotune/max autotune no cudagraphs, the console gets full of triton logs the first time it compiles, but then not anymore.

Let me know if it has too much comments or info.