### PR TITLE
Union ControlNet

### DIFF
--- a/backend/nn/cnets/cldm.py
+++ b/backend/nn/cnets/cldm.py
@@ -1,14 +1,59 @@
+# https://github.com/lllyasviel/ControlNet
+# https://github.com/Comfy-Org/ComfyUI/blob/v0.19.1/comfy/cldm/cldm.py
+
+from collections import OrderedDict
+
+import torch
 import torch.nn as nn
 
+from backend.attention import attention_function
 from backend.nn.unet import (
     Downsample,
     ResBlock,
     SpatialTransformer,
     TimestepEmbedSequential,
-    conv_nd,
     exists,
     timestep_embedding,
 )
+from backend.patcher.controlnet import logger
+
+
+class OptimizedAttention(nn.Module):
+    def __init__(self, c, nhead):
+        super().__init__()
+        self.heads = nhead
+        self.c = c
+
+        self.in_proj = nn.Linear(c, c * 3, bias=True)
+        self.out_proj = nn.Linear(c, c, bias=True)
+
+    def forward(self, x):
+        x = self.in_proj(x)
+        q, k, v = x.split(self.c, dim=2)
+        out = attention_function(q, k, v, self.heads)
+        return self.out_proj(out)
+
+
+class QuickGELU(nn.Module):
+    def forward(self, x: torch.Tensor):
+        return x * torch.sigmoid(1.702 * x)
+
+
+class ResBlockUnionControlnet(nn.Module):
+    def __init__(self, dim, nhead):
+        super().__init__()
+        self.attn = OptimizedAttention(dim, nhead)
+        self.ln_1 = nn.LayerNorm(dim)
+        self.mlp = nn.Sequential(OrderedDict([("c_fc", nn.Linear(dim, dim * 4)), ("gelu", QuickGELU()), ("c_proj", nn.Linear(dim * 4, dim))]))
+        self.ln_2 = nn.LayerNorm(dim)
+
+    def attention(self, x: torch.Tensor):
+        return self.attn(x)
+
+    def forward(self, x: torch.Tensor):
+        x = x + self.attention(self.ln_1(x))
+        x = x + self.mlp(self.ln_2(x))
+        return x
 
 
 class ControlNet(nn.Module):
@@ -42,6 +87,8 @@ class ControlNet(nn.Module):
         adm_in_channels=None,
         transformer_depth_middle=None,
         transformer_depth_output=None,
+        union_controlnet_num_control_type=None,
+        legacy=True,
         dtype=None,
         **kwargs,
     ):
@@ -49,7 +96,6 @@ class ControlNet(nn.Module):
         assert use_spatial_transformer
         if use_spatial_transformer:
             assert context_dim is not None
-
         if context_dim is not None:
             assert use_spatial_transformer
 
@@ -58,12 +104,12 @@ class ControlNet(nn.Module):
 
         if num_heads == -1:
             assert num_head_channels != -1
-
         if num_head_channels == -1:
             assert num_heads != -1
 
         self.dtype = dtype
         self.dims = dims
+        assert self.dims == 2
         self.in_channels = in_channels
         self.model_channels = model_channels
 
@@ -124,7 +170,7 @@ class ControlNet(nn.Module):
         else:
             c0, c1, c2, c3 = 16, 32, 96, 256
 
-        self.input_hint_block = TimestepEmbedSequential(conv_nd(dims, hint_channels, c0, 3, padding=1), nn.SiLU(), conv_nd(dims, c0, c0, 3, padding=1), nn.SiLU(), conv_nd(dims, c0, c1, 3, padding=1, stride=2), nn.SiLU(), conv_nd(dims, c1, c1, 3, padding=1), nn.SiLU(), conv_nd(dims, c1, c2, 3, padding=1, stride=2), nn.SiLU(), conv_nd(dims, c2, c2, 3, padding=1), nn.SiLU(), conv_nd(dims, c2, c3, 3, padding=1, stride=2), nn.SiLU(), conv_nd(dims, c3, model_channels, 3, padding=1))
+        self.input_hint_block = TimestepEmbedSequential(nn.Conv2d(hint_channels, c0, 3, padding=1), nn.SiLU(), nn.Conv2d(c0, c0, 3, padding=1), nn.SiLU(), nn.Conv2d(c0, c1, 3, padding=1, stride=2), nn.SiLU(), nn.Conv2d(c1, c1, 3, padding=1), nn.SiLU(), nn.Conv2d(c1, c2, 3, padding=1, stride=2), nn.SiLU(), nn.Conv2d(c2, c2, 3, padding=1), nn.SiLU(), nn.Conv2d(c2, c3, 3, padding=1, stride=2), nn.SiLU(), nn.Conv2d(c3, model_channels, 3, padding=1))
 
         self._feature_size = model_channels
         input_block_chans = [model_channels]
@@ -151,7 +197,8 @@ class ControlNet(nn.Module):
                     else:
                         num_heads = ch // num_head_channels
                         dim_head = num_head_channels
-
+                    if legacy:
+                        dim_head = ch // num_heads if use_spatial_transformer else num_head_channels
                     if exists(disable_self_attentions):
                         disabled_sa = disable_self_attentions[level]
                     else:
@@ -192,7 +239,8 @@ class ControlNet(nn.Module):
         else:
             num_heads = ch // num_head_channels
             dim_head = num_head_channels
-
+        if legacy:
+            dim_head = ch // num_heads if use_spatial_transformer else num_head_channels
         mid_block = [
             ResBlock(
                 ch,
@@ -219,18 +267,89 @@ class ControlNet(nn.Module):
         self.middle_block_out = self.make_zero_conv(ch)
         self._feature_size += ch
 
-    def make_zero_conv(self, channels):
-        return TimestepEmbedSequential(conv_nd(self.dims, channels, channels, 1, padding=0))
+        if union_controlnet_num_control_type is None:
+            self.task_embedding = None
+            self.control_add_embedding = None
+        else:
+            self.num_control_type = union_controlnet_num_control_type
+            num_trans_channel = 320
+            num_trans_head = 8
+            num_trans_layer = 1
+            num_proj_channel = 320
+            self.task_embedding = nn.Parameter(torch.empty(self.num_control_type, num_trans_channel))
 
-    def forward(self, x, hint, timesteps, context, y=None, **kwargs):
+            self.transformer_layes = nn.Sequential(*[ResBlockUnionControlnet(num_trans_channel, num_trans_head) for _ in range(num_trans_layer)])
+            self.spatial_ch_projs = nn.Linear(num_trans_channel, num_proj_channel)
+
+            control_add_embed_dim = 256
+
+            class ControlAddEmbedding(nn.Module):
+                def __init__(self, in_dim, out_dim, num_control_type):
+                    super().__init__()
+                    self.num_control_type = num_control_type
+                    self.in_dim = in_dim
+                    self.linear_1 = nn.Linear(in_dim * num_control_type, out_dim)
+                    self.linear_2 = nn.Linear(out_dim, out_dim)
+
+                def forward(self, control_type, dtype, device):
+                    c_type = torch.zeros((self.num_control_type,), device=device)
+                    c_type[control_type] = 1.0
+                    c_type = timestep_embedding(c_type.flatten(), self.in_dim, repeat_only=False).to(dtype).reshape((-1, self.num_control_type * self.in_dim))
+                    return self.linear_2(torch.nn.functional.silu(self.linear_1(c_type)))
+
+            self.control_add_embedding = ControlAddEmbedding(control_add_embed_dim, time_embed_dim, self.num_control_type)
+
+    def union_controlnet_merge(self, hint, control_type, emb, context):
+        # https://github.com/xinsir6/ControlNetPlus
+        inputs = []
+        condition_list = []
+
+        for idx in range(min(1, len(control_type))):
+            controlnet_cond = self.input_hint_block(hint[idx], emb, context)
+            feat_seq = torch.mean(controlnet_cond, dim=(2, 3))
+            if idx < len(control_type):
+                feat_seq += self.task_embedding[control_type[idx]].to(dtype=feat_seq.dtype, device=feat_seq.device)
+
+            inputs.append(feat_seq.unsqueeze(1))
+            condition_list.append(controlnet_cond)
+
+        x = torch.cat(inputs, dim=1)
+        x = self.transformer_layes(x)
+        controlnet_cond_fuser = None
+        for idx in range(len(control_type)):
+            alpha = self.spatial_ch_projs(x[:, idx])
+            alpha = alpha.unsqueeze(-1).unsqueeze(-1)
+            o = condition_list[idx] + alpha
+            if controlnet_cond_fuser is None:
+                controlnet_cond_fuser = o
+            else:
+                controlnet_cond_fuser += o
+        return controlnet_cond_fuser
+
+    def make_zero_conv(self, channels):
+        return TimestepEmbedSequential(nn.Conv2d(channels, channels, 1, padding=0))
+
+    def forward(self, x, hint, timesteps, context, y=None, control_type: list[int] = None, **kwargs):
         t_emb = timestep_embedding(timesteps, self.model_channels, repeat_only=False).to(x.dtype)
         emb = self.time_embed(t_emb)
+        guided_hint = None
 
-        guided_hint = self.input_hint_block(hint, emb, context)
+        if self.control_add_embedding is not None:  # Union Controlnet
+            if control_type is None:
+                logger.warning("Selecting a Control Type is recommended for Union ControlNet...")
+            elif any([c >= self.num_control_type for c in control_type]):
+                logger.error("Control Type is not supported...")
+            else:
+                emb += self.control_add_embedding(control_type, emb.dtype, emb.device)
+                if len(hint.shape) < 5:
+                    hint = hint.unsqueeze(0)
+                guided_hint = self.union_controlnet_merge(hint, control_type, emb, context)
+
+        if guided_hint is None:  # Regular Controlnet
+            guided_hint = self.input_hint_block(hint, emb, context)
 
         outs = []
 
-        hs = []
         if self.num_classes is not None:
             assert y.shape[0] == x.shape[0]
             emb = emb + self.label_emb(y)

--- a/backend/nn/cnets/control_types.py
+++ b/backend/nn/cnets/control_types.py
@@ -1,0 +1,20 @@
+from typing import Final
+
+UNION_CONTROLNET_TYPES: Final[dict[str, int]] = {
+    "OpenPose": 0,
+    "Depth": 1,
+    "Scribble/SoftEdge/Sketch": 2,
+    "Canny/Lineart/MLSD": 3,
+    "NormalMap": 4,
+    "Segmentation": 5,
+    "Tile": 6,
+    "Inpaint": 7,
+}
+
+
+def convert_control_type(control_type: str) -> int | None:
+    for keys, v in UNION_CONTROLNET_TYPES.items():
+        if control_type in keys:
+            return v
+
+    return None

--- a/backend/patcher/controlnet.py
+++ b/backend/patcher/controlnet.py
@@ -18,7 +18,8 @@ from backend.patcher.base import ModelPatcher
 logger = logging.getLogger("ControlNet")
 setup_logger(logger)
 
-def apply_controlnet_advanced(unet, controlnet, image_bchw, strength, start_percent, end_percent, positive_advanced_weighting=None, negative_advanced_weighting=None, advanced_frame_weighting=None, advanced_sigma_weighting=None, advanced_mask_weighting=None):
+
+def apply_controlnet_advanced(unet, controlnet, image_bchw, strength, start_percent, end_percent, positive_advanced_weighting=None, negative_advanced_weighting=None, advanced_frame_weighting=None, advanced_sigma_weighting=None, advanced_mask_weighting=None, control_type=None):
     """
 
     # positive_advanced_weighting or negative_advanced_weighting
@@ -63,7 +64,7 @@ def apply_controlnet_advanced(unet, controlnet, image_bchw, strength, start_perc
 
     """
 
-    cnet = controlnet.copy().set_cond_hint(image_bchw, strength, (start_percent, end_percent))
+    cnet = controlnet.copy().set_cond_hint(image_bchw, strength, (start_percent, end_percent)).set_control_type(control_type)
     cnet.positive_advanced_weighting = positive_advanced_weighting
     cnet.negative_advanced_weighting = negative_advanced_weighting
     cnet.advanced_frame_weighting = advanced_frame_weighting
@@ -176,6 +177,7 @@ class ControlBase:
         self.global_average_pooling = False
         self.timestep_range = None
         self.transformer_options = {}
+        self.control_type = None
 
         if device is None:
             device = memory_management.get_torch_device()
@@ -186,6 +188,10 @@ class ControlBase:
         self.cond_hint_original = cond_hint
         self.strength = strength
         self.timestep_percent_range = timestep_percent_range
+        return self
+
+    def set_control_type(self, control_type):
+        self.control_type = [control_type]
         return self
 
     def pre_run(self, model, percent_to_timestep_function):
@@ -324,12 +330,12 @@ class ControlNet(ControlBase):
         controlnet_model_function_wrapper = to.get("controlnet_model_function_wrapper", None)
 
         if controlnet_model_function_wrapper is not None:
-            wrapper_args = dict(x=x_noisy.to(dtype), hint=self.cond_hint, timesteps=timestep.float(), context=context.to(dtype), y=y)
+            wrapper_args = dict(x=x_noisy.to(dtype), hint=self.cond_hint, timesteps=timestep.float(), context=context.to(dtype), y=y, control_type=self.control_type)
             wrapper_args["model"] = self
             wrapper_args["inner_model"] = self.control_model
             control = controlnet_model_function_wrapper(**wrapper_args)
         else:
-            control = self.control_model(x=x_noisy.to(dtype), hint=self.cond_hint.to(self.device), timesteps=timestep.float(), context=context.to(dtype), y=y)
+            control = self.control_model(x=x_noisy.to(dtype), hint=self.cond_hint.to(self.device), timesteps=timestep.float(), context=context.to(dtype), y=y, control_type=self.control_type)
         return self.control_merge(None, control, control_prev, output_dtype)
 
     def copy(self):

--- a/backend/patcher/controlnet.py
+++ b/backend/patcher/controlnet.py
@@ -1,8 +1,10 @@
+import logging
 import math
 
 import torch
 
 from backend import memory_management, state_dict, utils
+from backend.logging import setup_logger
 from backend.misc import image_resize
 from backend.nn.cnets import cldm, t2i_adapter
 from backend.operations import (
@@ -13,6 +15,8 @@ from backend.operations import (
 )
 from backend.patcher.base import ModelPatcher
 
+logger = logging.getLogger("ControlNet")
+setup_logger(logger)
 
 def apply_controlnet_advanced(unet, controlnet, image_bchw, strength, start_percent, end_percent, positive_advanced_weighting=None, negative_advanced_weighting=None, advanced_frame_weighting=None, advanced_sigma_weighting=None, advanced_mask_weighting=None):
     """

--- a/backend/patcher/controlnet.py
+++ b/backend/patcher/controlnet.py
@@ -191,7 +191,10 @@ class ControlBase:
         return self
 
     def set_control_type(self, control_type):
-        self.control_type = [control_type]
+        if control_type is None:
+            self.control_type = None
+        else:
+            self.control_type = [control_type]
         return self
 
     def pre_run(self, model, percent_to_timestep_function):

--- a/extensions-builtin/sd_forge_controlnet/lib_controlnet/controlnet_ui/controlnet_ui_group.py
+++ b/extensions-builtin/sd_forge_controlnet/lib_controlnet/controlnet_ui/controlnet_ui_group.py
@@ -493,7 +493,7 @@ class ControlNetUiGroup:
 
         (ControlNetUiGroup.a1111_context.img2img_submit_button if self.is_img2img else ControlNetUiGroup.a1111_context.txt2img_submit_button).click(
             fn=UiControlNetUnit,
-            inputs=list(unit_args),
+            inputs=list(unit_args) + [self.type_filter],
             outputs=unit,
             queue=False,
         )

--- a/extensions-builtin/sd_forge_controlnet/lib_controlnet/external_code.py
+++ b/extensions-builtin/sd_forge_controlnet/lib_controlnet/external_code.py
@@ -171,6 +171,7 @@ class ControlNetUnit:
     guidance_end: float = 1.0
     pixel_perfect: bool = False
     control_mode: ControlMode | int | str = ControlMode.BALANCED
+    type_filter: str = "All"
     save_detected_map: bool = True
     _idx: int = -1
 

--- a/extensions-builtin/sd_forge_controlnet/lib_controlnet/global_state.py
+++ b/extensions-builtin/sd_forge_controlnet/lib_controlnet/global_state.py
@@ -62,7 +62,7 @@ def get_controlnet_filename(controlnet_name: str) -> str:
 
 
 def get_filtered_controlnet_names(tag: str) -> list[str]:
-    filename_filters = ["union", "promax"]
+    filename_filters = ["union", "promax", "unicontrol"]
 
     filtered_preprocessors = get_filtered_preprocessors(tag)
     for p in filtered_preprocessors.values():

--- a/extensions-builtin/sd_forge_controlnet/scripts/controlnet.py
+++ b/extensions-builtin/sd_forge_controlnet/scripts/controlnet.py
@@ -24,6 +24,7 @@ from PIL import Image
 
 import modules.scripts as scripts
 import modules.util as util
+from backend.nn.cnets.control_types import convert_control_type
 from modules import images, masking, script_callbacks, shared
 from modules.processing import (
     StableDiffusionProcessing,
@@ -37,7 +38,7 @@ from modules_forge.utils import HWC3, numpy_to_pytorch
 global_state.update_controlnet_filenames()
 
 
-@functools.lru_cache(maxsize=shared.opts.data.get("control_net_model_cache_size", 5))
+@functools.lru_cache(maxsize=shared.opts.data.get("control_net_model_cache_size", 1))
 def cached_controlnet_loader(filename):
     return try_load_supported_control_model(filename)
 
@@ -455,7 +456,7 @@ class ControlNetForForgeOfficial(scripts.Script):
 
         params.model.advanced_mask_weighting = mask
 
-        params.model.process_before_every_sampling(p, cond, mask, *args, **kwargs)
+        params.model.process_before_every_sampling(p, cond, mask, *args, **kwargs, control_type=convert_control_type(unit.type_filter))
 
         logger.info(f"ControlNet Method {params.preprocessor.name} patched.")
         return
@@ -547,7 +548,7 @@ def on_ui_settings():
     shared.opts.add_option(
         "control_net_model_cache_size",
         shared.OptionInfo(
-            3,
+            1,
             "Number of Models to Cache in Memory",
             gr.Slider,
             {"minimum": 0, "maximum": 10, "step": 1},

--- a/extensions-builtin/sd_forge_controlnet/scripts/controlnet.py
+++ b/extensions-builtin/sd_forge_controlnet/scripts/controlnet.py
@@ -1,4 +1,3 @@
-import functools
 import os.path
 from typing import Optional
 
@@ -36,11 +35,6 @@ from modules_forge.supported_controlnet import ControlModelPatcher
 from modules_forge.utils import HWC3, numpy_to_pytorch
 
 global_state.update_controlnet_filenames()
-
-
-@functools.lru_cache(maxsize=shared.opts.data.get("control_net_model_cache_size", 1))
-def cached_controlnet_loader(filename):
-    return try_load_supported_control_model(filename)
 
 
 class ControlNetCachedParameters:
@@ -381,7 +375,7 @@ class ControlNetForForgeOfficial(scripts.Script):
         else:
             assert unit.model != "None", "You have not selected any control model!"
             model_filename = global_state.get_controlnet_filename(unit.model)
-            params.model = cached_controlnet_loader(model_filename)
+            params.model = try_load_supported_control_model(model_filename)
             assert params.model is not None, logger.error(f"Recognizing Control Model failed: {model_filename}")
 
         params.preprocessor = preprocessor

--- a/modules_forge/supported_controlnet.py
+++ b/modules_forge/supported_controlnet.py
@@ -1,4 +1,5 @@
 import os
+from collections import OrderedDict
 
 import torch
 
@@ -19,6 +20,28 @@ from modules_forge.packages.huggingface_guess.detection import (
     unet_config_from_diffusers_unet,
 )
 from modules_forge.shared import add_supported_control_model
+
+
+class ModelCache:
+    def __init__(self):
+        self.cache = OrderedDict()
+
+    def get(self, key):
+        if key in self.cache:
+            self.cache.move_to_end(key)
+            return self.cache[key]
+        return None
+
+    def put(self, key, model):
+        self.cache[key] = model
+        self.cache.move_to_end(key)
+
+        max_size = max(1, shared.opts.data.get("control_net_model_cache_size", 3))
+        while len(self.cache) > max_size:
+            self.cache.popitem(last=False)
+
+
+_CONTROL_MODEL_CACHE = ModelCache()
 
 
 class ControlModelPatcher:
@@ -138,27 +161,36 @@ class ControlNetPatcher(ControlModelPatcher):
         controlnet_config["hint_channels"] = controlnet_data["{}input_hint_block.0.weight".format(prefix)].shape[1]
         controlnet_config["hint_width"] = controlnet_data["{}input_hint_block.0.weight".format(prefix)].shape[0]
 
-        with using_forge_operations(dtype=unet_dtype, manual_cast_enabled=computation_dtype != unet_dtype):
-            control_model = cldm.ControlNet(**controlnet_config).to(dtype=unet_dtype)
+        global _CONTROL_MODEL_CACHE
+        control_model = _CONTROL_MODEL_CACHE.get(ckpt_path)
 
-        if pth:
-            if "difference" in controlnet_data:
-                logger.warning("Please use an official Control model for better performance...")
-
-            class WeightsLoader(torch.nn.Module):
-                pass
-
-            w = WeightsLoader()
-            w.control_model = control_model
-            missing, unexpected = w.load_state_dict(controlnet_data, strict=False)
+        if control_model is not None:
+            logger.info("Reusing ControlNet Model...")
         else:
-            missing, unexpected = control_model.load_state_dict(controlnet_data, strict=False)
+            logger.info("Creating ControlNet Model...")
+            with using_forge_operations(dtype=unet_dtype, manual_cast_enabled=computation_dtype != unet_dtype):
+                control_model = cldm.ControlNet(**controlnet_config).to(dtype=unet_dtype)
 
-        if len(missing) > 0:
-            logger.warning("Missing ControlNet Keys: {}".format(missing))
+            if pth:
+                if "difference" in controlnet_data:
+                    logger.warning("Please use an official Control model for better performance...")
 
-        if len(unexpected) > 0:
-            logger.debug("Unexpected ControlNet Keys: {}".format(unexpected))
+                class WeightsLoader(torch.nn.Module):
+                    pass
+
+                w = WeightsLoader()
+                w.control_model = control_model
+                missing, unexpected = w.load_state_dict(controlnet_data, strict=False)
+            else:
+                missing, unexpected = control_model.load_state_dict(controlnet_data, strict=False)
+
+            if len(missing) > 0:
+                logger.warning("Missing ControlNet Keys: {}".format(missing))
+
+            if len(unexpected) > 0:
+                logger.debug("Unexpected ControlNet Keys: {}".format(unexpected))
+
+            _CONTROL_MODEL_CACHE.put(ckpt_path, control_model)
 
         global_average_pooling = False
         filename = os.path.splitext(ckpt_path)[0]

--- a/modules_forge/supported_controlnet.py
+++ b/modules_forge/supported_controlnet.py
@@ -10,6 +10,7 @@ from backend.patcher.controlnet import (
     ControlNet,
     apply_controlnet_advanced,
     load_t2i_adapter,
+    logger,
 )
 from modules import shared
 from modules_forge.packages.comfy.utils import unet_to_diffusers
@@ -99,9 +100,15 @@ class ControlNetPatcher(ControlModelPatcher):
                 if k in controlnet_data:
                     new_sd[diffusers_keys[k]] = controlnet_data.pop(k)
 
+            if "control_add_embedding.linear_1.bias" in controlnet_data:  # Union Controlnet
+                controlnet_config["union_controlnet_num_control_type"] = controlnet_data["task_embedding"].shape[0]
+                for k in list(controlnet_data.keys()):
+                    new_k = k.replace(".attn.in_proj_", ".attn.in_proj.")
+                    new_sd[new_k] = controlnet_data.pop(k)
+
             leftover_keys = controlnet_data.keys()
             if len(leftover_keys) > 0:
-                print("leftover keys:", leftover_keys)
+                logger.warning("Leftover Keys: {}".format(leftover_keys))
             controlnet_data = new_sd
 
         pth_key = "control_model.zero_convs.0.0.weight"
@@ -116,6 +123,7 @@ class ControlNetPatcher(ControlModelPatcher):
         else:
             net = load_t2i_adapter(controlnet_data)
             if net is None:
+                logger.error("Could not detect Control model type...")
                 return None
             return ControlNetPatcher(net)
 
@@ -135,7 +143,7 @@ class ControlNetPatcher(ControlModelPatcher):
 
         if pth:
             if "difference" in controlnet_data:
-                print("WARNING: Your controlnet model is diff version rather than official float16 model. " "Please use an official float16/float32 model for robust performance.")
+                logger.warning("Please use an official Control model for better performance...")
 
             class WeightsLoader(torch.nn.Module):
                 pass
@@ -145,7 +153,12 @@ class ControlNetPatcher(ControlModelPatcher):
             missing, unexpected = w.load_state_dict(controlnet_data, strict=False)
         else:
             missing, unexpected = control_model.load_state_dict(controlnet_data, strict=False)
-        print(missing, unexpected)
+
+        if len(missing) > 0:
+            logger.warning("Missing ControlNet Keys: {}".format(missing))
+
+        if len(unexpected) > 0:
+            logger.debug("Unexpected ControlNet Keys: {}".format(unexpected))
 
         global_average_pooling = False
         filename = os.path.splitext(ckpt_path)[0]

--- a/modules_forge/supported_controlnet.py
+++ b/modules_forge/supported_controlnet.py
@@ -169,7 +169,7 @@ class ControlNetPatcher(ControlModelPatcher):
         control = ControlNet(control_model, global_average_pooling=global_average_pooling, load_device=load_device, manual_cast_dtype=computation_dtype)
         return ControlNetPatcher(control)
 
-    def process_before_every_sampling(self, process, cond, mask, *args, **kwargs):
+    def process_before_every_sampling(self, process, cond, mask, *args, control_type=None, **kwargs):
         unet = process.sd_model.forge_objects.unet
         unet = apply_controlnet_advanced(
             unet=unet,
@@ -183,6 +183,7 @@ class ControlNetPatcher(ControlModelPatcher):
             advanced_frame_weighting=self.advanced_frame_weighting,
             advanced_sigma_weighting=self.advanced_sigma_weighting,
             advanced_mask_weighting=self.advanced_mask_weighting,
+            control_type=control_type,
         )
         process.sd_model.forge_objects.unet = unet
 


### PR DESCRIPTION
- Allow you to pass the `control_type` to the **Union** ControlNet to "select" the mode
- Optimize the memory usage of duplicated models
- **Union Models:**
    - [SDXL Union ProMax](https://huggingface.co/xinsir/controlnet-union-sdxl-1.0)
    - [Chenkin UniControl](https://civitai.com/models/2527960/chenkin-unicontrol-xl)

<hr>

#### Inpaint Example

<table>
	<thead>
		<tr>
			<th>Off</th>
			<th>On</th>
		</tr>
	</thead>
	<tbody>
		<tr>
			<td><img height="384" src="https://github.com/user-attachments/assets/f625646a-3f81-4cdd-9b03-b74817dbad5b"></td>
			<td><img height="384" src="https://github.com/user-attachments/assets/9ab447f5-3f05-433e-9757-682cb4a8e902"></td>
		</tr>
	</tbody>
</table>
