### PR TITLE
Add Docker setup for NVIDIA GPU / Unraid deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ The name "Forge" is inspired by "Minecraft Forge". This project aims to become t
 > For **Linux** and **macOS**, refer to [Wiki](https://github.com/Haoming02/sd-webui-forge-classic/wiki/Unix)
 
 > [!Tip]
-> For **Docker** (`Nvidia`), refer to [docker](docker/)
+> For **Docker** (`Nvidia`), refer to [Docker](docker/)
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ The name "Forge" is inspired by "Minecraft Forge". This project aims to become t
 > For **Linux** and **macOS**, refer to [Wiki](https://github.com/Haoming02/sd-webui-forge-classic/wiki/Unix)
 
 > [!Tip]
-> For **Docker** deployment *(NVIDIA GPU)*, refer to [`docker/`](docker/)
+> For **Docker** (`Nvidia`), refer to [docker](docker/)
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -328,6 +328,9 @@ The name "Forge" is inspired by "Minecraft Forge". This project aims to become t
 > [!Tip]
 > For **Linux** and **macOS**, refer to [Wiki](https://github.com/Haoming02/sd-webui-forge-classic/wiki/Unix)
 
+> [!Tip]
+> For **Docker** deployment *(NVIDIA GPU)*, refer to [`docker/`](docker/)
+
 <br>
 
 > [!Tip]

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,6 +1,6 @@
-.DS_Store
 __pycache__
+.DS_Store
 data
+*.log
 *.pyc
 *.pyo
-*.log

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,6 +1,6 @@
-data/
-__pycache__/
+.DS_Store
+__pycache__
+data
 *.pyc
 *.pyo
-.DS_Store
 *.log

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,6 @@
+data/
+__pycache__/
+*.pyc
+*.pyo
+.DS_Store
+*.log

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ ARG TORCH_INDEX=cu124
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    # Allow uv to fetch the Python 3.13 standalone runtime if not on the system.
+    # Allow uv to fetch the Python 3.12 standalone runtime if not on the system.
     UV_PYTHON_DOWNLOADS=automatic
 
 # ── uv binary (from the official image — no installer script, no PATH guessing)
@@ -48,9 +48,9 @@ RUN git clone --branch neo --depth 1 \
 
 USER forge
 
-# ── Python 3.13 virtual environment ──────────────────────────────────────────
+# ── Python 3.12 virtual environment ──────────────────────────────────────────
 # --seed pre-installs pip/setuptools/wheel for packages that expect them.
-# uv fetches the Python 3.13 standalone build automatically if needed.
+# uv fetches the Python 3.12 standalone build automatically if needed.
 RUN uv venv venv --python 3.12 --seed
 
 ENV VIRTUAL_ENV=/home/forge/sd-webui/venv \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,20 +1,22 @@
 # syntax=docker/dockerfile:1
-# Forge Classic – neo branch | NVIDIA GPU (RTX 3060, CUDA 12.4)
+# Forge Classic – neo branch | NVIDIA GPU
 
-ARG CUDA_VERSION=12.4.1
+ARG CUDA_VERSION=12.6.1
 
 FROM nvidia/cuda:${CUDA_VERSION}-cudnn-runtime-ubuntu22.04
 
 # Match the CUDA wheels PyTorch was compiled against.
 # Available variants: cu118, cu121, cu124, cu126 …
 # See: https://download.pytorch.org/whl/
-ARG TORCH_INDEX=cu124
+ARG TORCH_INDEX=cu126
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    # Allow uv to fetch the Python 3.12 standalone runtime if not on the system.
-    UV_PYTHON_DOWNLOADS=automatic
+    # Allow uv to fetch the Python 3.13 standalone runtime if not on the system.
+    UV_PYTHON_DOWNLOADS=automatic \
+    # Tells prepare_environment() which index to use for optional packages (e.g. xformers).
+    TORCH_INDEX_URL=https://download.pytorch.org/whl/${TORCH_INDEX}
 
 # ── uv binary (from the official image — no installer script, no PATH guessing)
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
@@ -48,50 +50,23 @@ RUN git clone --branch neo --depth 1 \
 
 USER forge
 
-# ── Python 3.12 virtual environment ──────────────────────────────────────────
+# ── Python 3.13 virtual environment ──────────────────────────────────────────
 # --seed pre-installs pip/setuptools/wheel for packages that expect them.
-# uv fetches the Python 3.12 standalone build automatically if needed.
-RUN uv venv venv --python 3.12 --seed
+RUN uv venv venv --python 3.13 --seed
 
 ENV VIRTUAL_ENV=/home/forge/sd-webui/venv \
     PATH="/home/forge/sd-webui/venv/bin:$PATH" \
     # Override the Unraid template's PYTHON default to use the venv runtime.
-    PYTHON=/home/forge/sd-webui/venv/bin/python3.12
+    PYTHON=/home/forge/sd-webui/venv/bin/python3.13
 
-# Install PyTorch with CUDA support before requirements.txt so the pinned
-# CUDA-enabled wheel is not overwritten by a CPU-only fallback.
+# ── PyTorch pre-install ───────────────────────────────────────────────────────
+# Baked in at build time so the ~2 GB download does not happen on first start.
+# prepare_environment() checks is_installed("torch") and skips this step when
+# torch is already present, so the runtime install path is never hit.
 RUN uv pip install \
         torch \
         torchvision \
-        xformers \
         --index-url "https://download.pytorch.org/whl/${TORCH_INDEX}"
-
-# Install remaining project requirements.
-# The bare `torch` entry in requirements.txt will already be satisfied above.
-RUN uv pip install -r requirements.txt imageio-ffmpeg
-
-# Pre-install gradio and extension/preprocessor dependencies so that
-# prepare_environment() on first start becomes a fast verification pass
-# rather than a ~65s download+install run.
-RUN uv pip install \
-        python-dotenv \
-        pillow-avif-plugin \
-        lxml \
-        filetype \
-        "hnswlib>=0.0.0,<1.0.0" \
-        send2trash \
-        ZipUnicode \
-        beautifulsoup4 \
-        pysocks \
-        addict \
-        ftfy \
-        fvcore \
-        mediapipe \
-        onnx \
-        onnxruntime \
-        timm \
-        yapf \
-        insightface
 
 # ── Persistent data directories ───────────────────────────────────────────────
 # These are bind-mount targets; actual data lives on the Unraid host.
@@ -112,8 +87,8 @@ RUN chmod +x /home/forge/sd-webui/entrypoint.sh
 
 EXPOSE 7860
 
-# Allow extra time for initial model loading before the health probe fires.
-HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=15 \
+# Allow extra time for prepare_environment() to run on first start.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=300s --retries=15 \
     CMD curl -f http://localhost:7860/ || exit 1
 
 ENTRYPOINT ["/home/forge/sd-webui/entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,95 +1,76 @@
 # syntax=docker/dockerfile:1
-# Forge Classic – neo branch | NVIDIA GPU
+# Forge Neo | NVIDIA GPU
 
-ARG CUDA_VERSION=12.6.1
+ARG CUDA_VERSION=12.6.3
 
 FROM nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu22.04
 
-# Match the CUDA wheels PyTorch was compiled against.
-# Available variants: cu118, cu121, cu124, cu126 …
 # See: https://download.pytorch.org/whl/
 ARG TORCH_INDEX=cu126
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    # Allow uv to fetch the Python 3.13 standalone runtime if not on the system.
     UV_PYTHON_DOWNLOADS=automatic \
     UV_NO_CACHE=1 \
-    # Tells prepare_environment() which index to use for optional packages (e.g. xformers).
     TORCH_INDEX_URL=https://download.pytorch.org/whl/${TORCH_INDEX}
 
-# ── uv binary (from the official image — no installer script, no PATH guessing)
+# uv binary
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
-# ── System dependencies ───────────────────────────────────────────────────────
-# ffmpeg               – required by the project (av / media processing)
-# libtcmalloc-minimal4 – reduces memory fragmentation for large model workloads
+# Dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        git \
+        build-essential \
         curl \
         ffmpeg \
-        build-essential \
+        git \
+        google-perftools \
         libgl1 \
         libglib2.0-0 \
         libgomp1 \
         libtcmalloc-minimal4 \
     && rm -rf /var/lib/apt/lists/*
 
-# ── Non-root user (UID 99 / GID 100 = Unraid's nobody:users) ─────────────────
-# GID 100 may already exist in the base image; the || true swallows the error.
+# Non-Root User (UID 99 / GID 100 = nobody:users)
 RUN groupadd -g 100 users 2>/dev/null || true \
     && useradd -u 99 -g 100 -d /home/forge -m -s /bin/bash forge
 
 WORKDIR /home/forge/sd-webui
 
-# ── Source code ───────────────────────────────────────────────────────────────
-# Cloned at build time; rebuild the image to pick up upstream changes.
-RUN git clone --branch neo --depth 1 \
+# Clone at build time
+RUN git clone --branch neo --depth 1 --filter blob:none \
         https://github.com/Haoming02/sd-webui-forge-classic.git . \
     && chown -R 99:100 /home/forge
 
 USER forge
 
-# ── Python 3.13 virtual environment ──────────────────────────────────────────
-# --seed pre-installs pip/setuptools/wheel for packages that expect them.
+# Python 3.13 Virtual ENVironment
 RUN uv venv venv --python 3.13 --seed
 
-ENV VIRTUAL_ENV=/home/forge/sd-webui/venv \
+ENV VIRTUAL_ENV="/home/forge/sd-webui/venv" \
     PATH="/home/forge/sd-webui/venv/bin:$PATH" \
-    # Override the Unraid template's PYTHON default to use the venv runtime.
-    PYTHON=/home/forge/sd-webui/venv/bin/python3.13
+    PYTHON="/home/forge/sd-webui/venv/bin/python3.13"
 
-# ── PyTorch pre-install ───────────────────────────────────────────────────────
-# Baked in at build time so the ~2 GB download does not happen on first start.
-# prepare_environment() checks is_installed("torch") and skips this step when
-# torch is already present, so the runtime install path is never hit.
-RUN uv pip install --no-cache \
-        torch \
-        torchvision \
-        --index-url "https://download.pytorch.org/whl/${TORCH_INDEX}"
+# PyTorch Pre-Install
+RUN uv pip install torch torchvision \
+    --index-url "https://download.pytorch.org/whl/${TORCH_INDEX}"
 
-# ── Persistent data directories ───────────────────────────────────────────────
-# These are bind-mount targets; actual data lives on the Unraid host.
-# `outputs` is symlinked to `output` because Forge writes to the former
-# while the Unraid template mounts the latter.
+# Persistent Data Directories
 RUN mkdir -p \
         models/Stable-diffusion \
         models/VAE \
         models/Lora \
         models/ControlNet \
         extensions \
-        output \
-        config \
-    && ln -s /home/forge/sd-webui/output /home/forge/sd-webui/outputs
+        output
 
-# ── Runtime ───────────────────────────────────────────────────────────────────
+# Runtime
 COPY --chown=99:100 entrypoint.sh /home/forge/sd-webui/entrypoint.sh
 RUN chmod +x /home/forge/sd-webui/entrypoint.sh
 
 EXPOSE 7860
 
-# Allow extra time for prepare_environment() to run on first start.
+# extra time for prepare_environment() to run on first start
 HEALTHCHECK --interval=30s --timeout=10s --start-period=300s --retries=15 \
     CMD curl -f http://localhost:7860/ || exit 1
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,6 +61,7 @@ RUN mkdir -p \
         models/Lora \
         models/ControlNet \
         extensions \
+        config \
         output
 
 # Runtime

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@
 
 ARG CUDA_VERSION=12.6.1
 
-FROM nvidia/cuda:${CUDA_VERSION}-cudnn-runtime-ubuntu22.04
+FROM nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu22.04
 
 # Match the CUDA wheels PyTorch was compiled against.
 # Available variants: cu118, cu121, cu124, cu126 …
@@ -15,6 +15,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONDONTWRITEBYTECODE=1 \
     # Allow uv to fetch the Python 3.13 standalone runtime if not on the system.
     UV_PYTHON_DOWNLOADS=automatic \
+    UV_NO_CACHE=1 \
     # Tells prepare_environment() which index to use for optional packages (e.g. xformers).
     TORCH_INDEX_URL=https://download.pytorch.org/whl/${TORCH_INDEX}
 
@@ -63,7 +64,7 @@ ENV VIRTUAL_ENV=/home/forge/sd-webui/venv \
 # Baked in at build time so the ~2 GB download does not happen on first start.
 # prepare_environment() checks is_installed("torch") and skips this step when
 # torch is already present, so the runtime install path is never hit.
-RUN uv pip install \
+RUN uv pip install --no-cache \
         torch \
         torchvision \
         --index-url "https://download.pytorch.org/whl/${TORCH_INDEX}"
@@ -79,6 +80,7 @@ RUN mkdir -p \
         models/ControlNet \
         extensions \
         output \
+        config \
     && ln -s /home/forge/sd-webui/output /home/forge/sd-webui/outputs
 
 # ── Runtime ───────────────────────────────────────────────────────────────────

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         ffmpeg \
         git \
-        google-perftools \
         libgl1 \
         libglib2.0-0 \
         libgomp1 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,119 @@
+# syntax=docker/dockerfile:1
+# Forge Classic – neo branch | NVIDIA GPU (RTX 3060, CUDA 12.4)
+
+ARG CUDA_VERSION=12.4.1
+
+FROM nvidia/cuda:${CUDA_VERSION}-cudnn-runtime-ubuntu22.04
+
+# Match the CUDA wheels PyTorch was compiled against.
+# Available variants: cu118, cu121, cu124, cu126 …
+# See: https://download.pytorch.org/whl/
+ARG TORCH_INDEX=cu124
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    # Allow uv to fetch the Python 3.13 standalone runtime if not on the system.
+    UV_PYTHON_DOWNLOADS=automatic
+
+# ── uv binary (from the official image — no installer script, no PATH guessing)
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# ── System dependencies ───────────────────────────────────────────────────────
+# ffmpeg               – required by the project (av / media processing)
+# libtcmalloc-minimal4 – reduces memory fragmentation for large model workloads
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git \
+        curl \
+        ffmpeg \
+        build-essential \
+        libgl1 \
+        libglib2.0-0 \
+        libgomp1 \
+        libtcmalloc-minimal4 \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Non-root user (UID 99 / GID 100 = Unraid's nobody:users) ─────────────────
+# GID 100 may already exist in the base image; the || true swallows the error.
+RUN groupadd -g 100 users 2>/dev/null || true \
+    && useradd -u 99 -g 100 -d /home/forge -m -s /bin/bash forge
+
+WORKDIR /home/forge/sd-webui
+
+# ── Source code ───────────────────────────────────────────────────────────────
+# Cloned at build time; rebuild the image to pick up upstream changes.
+RUN git clone --branch neo --depth 1 \
+        https://github.com/Haoming02/sd-webui-forge-classic.git . \
+    && chown -R 99:100 /home/forge
+
+USER forge
+
+# ── Python 3.13 virtual environment ──────────────────────────────────────────
+# --seed pre-installs pip/setuptools/wheel for packages that expect them.
+# uv fetches the Python 3.13 standalone build automatically if needed.
+RUN uv venv venv --python 3.12 --seed
+
+ENV VIRTUAL_ENV=/home/forge/sd-webui/venv \
+    PATH="/home/forge/sd-webui/venv/bin:$PATH" \
+    # Override the Unraid template's PYTHON default to use the venv runtime.
+    PYTHON=/home/forge/sd-webui/venv/bin/python3.12
+
+# Install PyTorch with CUDA support before requirements.txt so the pinned
+# CUDA-enabled wheel is not overwritten by a CPU-only fallback.
+RUN uv pip install \
+        torch \
+        torchvision \
+        xformers \
+        --index-url "https://download.pytorch.org/whl/${TORCH_INDEX}"
+
+# Install remaining project requirements.
+# The bare `torch` entry in requirements.txt will already be satisfied above.
+RUN uv pip install -r requirements.txt imageio-ffmpeg
+
+# Pre-install gradio and extension/preprocessor dependencies so that
+# prepare_environment() on first start becomes a fast verification pass
+# rather than a ~65s download+install run.
+RUN uv pip install \
+        python-dotenv \
+        pillow-avif-plugin \
+        lxml \
+        filetype \
+        "hnswlib>=0.0.0,<1.0.0" \
+        send2trash \
+        ZipUnicode \
+        beautifulsoup4 \
+        pysocks \
+        addict \
+        ftfy \
+        fvcore \
+        mediapipe \
+        onnx \
+        onnxruntime \
+        timm \
+        yapf \
+        insightface
+
+# ── Persistent data directories ───────────────────────────────────────────────
+# These are bind-mount targets; actual data lives on the Unraid host.
+# `outputs` is symlinked to `output` because Forge writes to the former
+# while the Unraid template mounts the latter.
+RUN mkdir -p \
+        models/Stable-diffusion \
+        models/VAE \
+        models/Lora \
+        models/ControlNet \
+        extensions \
+        output \
+    && ln -s /home/forge/sd-webui/output /home/forge/sd-webui/outputs
+
+# ── Runtime ───────────────────────────────────────────────────────────────────
+COPY --chown=99:100 entrypoint.sh /home/forge/sd-webui/entrypoint.sh
+RUN chmod +x /home/forge/sd-webui/entrypoint.sh
+
+EXPOSE 7860
+
+# Allow extra time for initial model loading before the health probe fires.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=15 \
+    CMD curl -f http://localhost:7860/ || exit 1
+
+ENTRYPOINT ["/home/forge/sd-webui/entrypoint.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -31,19 +31,15 @@
 		</td>
 		<td>User-Installed Extensions</td>
 	</tr>
+	<tr>
+		<td>
+			<code>/home/forge/sd-webui/config</code>
+		</td>
+		<td>User Settings</td>
+	</tr>
 </table>
 
 - The container runs as **UID 99** / **GID 100** (`nobody:users`) to match Unraid's default share permissions
-
-<hr>
-
-## Pre-built Image
-
-A pre-built image with this code is maintained on Docker Hub by [@oromis995](https://github.com/oromis995):
-
-```bash
-docker pull oromis995/sd-forge-neo:latest
-```
 
 <hr>
 
@@ -57,7 +53,17 @@ docker build -t forge-neo-local .
 
 <hr>
 
-## Image details
+## Pre-Built Image
+
+> a non-official pre-built image is maintained on Docker Hub by [@oromis995](https://github.com/oromis995):
+
+```bash
+docker pull oromis995/sd-forge-neo:latest
+```
+
+<hr>
+
+## Image Details
 
 <table>
 	<tr>

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,69 +1,76 @@
-# SD-WebUI Forge Neo (Docker)
+<h2 align="center">Stable Diffusion WebUI Forge - Neo (Docker)</h2>
 
-Docker image for [sd-webui-forge-classic (neo branch)](https://github.com/Haoming02/sd-webui-forge-classic/tree/neo) by Haoming02.
+> [!Warning]
+> Requires an **NVIDIA** GPU<br>
+> Ensure driver is up to date (`560+` required)
 
-**Docker Hub:** `oromis995/sd-forge-neo`
+<hr>
 
-> ⚠ Requires an NVIDIA GPU. The application cannot run without one.
-> ⚠ Ensure NVIDIA drivers are up to date (560+ required for CUDA 12.6).
+## Unraid Deployment
 
----
+<table>
+	<tr>
+		<th>Container Path</th>
+		<th>Purpose</th>
+	</tr>
+	<tr>
+		<td>
+			<code>/home/forge/sd-webui/models</code>
+		</td>
+		<td>Checkpoint, Text Encoder, VAE, LoRA, ControlNet</td>
+	</tr>
+	<tr>
+		<td>
+			<code>/home/forge/sd-webui/output</code>
+		</td>
+		<td>Generated Images</td>
+	</tr>
+	<tr>
+		<td>
+			<code>/home/forge/sd-webui/extensions</code>
+		</td>
+		<td>User-Installed Extensions</td>
+	</tr>
+</table>
 
-## Unraid deployment
+- The container runs as **UID 99** / **GID 100** (`nobody:users`) to match Unraid's default share permissions
 
-| Container path | Purpose |
-|---|---|
-| `/home/forge/sd-webui/models` | Checkpoints, VAEs, LoRAs, ControlNet weights |
-| `/home/forge/sd-webui/output` | Generated images |
-| `/home/forge/sd-webui/extensions` | User-installed extensions |
-| `/home/forge/sd-webui/config` | Settings (`config.json`, `ui-config.json`, `styles.csv`, etc.) |
+<hr>
 
-The container runs as UID 99 / GID 100 (`nobody:users`) to match Unraid's default share permissions.
-
----
-
-## Manual docker run
-
-```bash
-docker run -d \
-  --gpus all \
-  -p 7860:7860 \
-  -v /path/to/models:/home/forge/sd-webui/models \
-  -v /path/to/outputs:/home/forge/sd-webui/output \
-  -v /path/to/extensions:/home/forge/sd-webui/extensions \
-  -v /path/to/config:/home/forge/sd-webui/config \
-  oromis995/sd-forge-neo:latest
-```
-
-Pass extra flags via `-e COMMANDLINE_ARGS="..."` if needed (e.g. `--api`, `--xformers`, `--cuda-malloc`).
-
-Access the WebUI at `http://<host-ip>:7860`.
-
----
-
-## Building locally
+## Building Locally
 
 ```bash
-git clone --branch neo https://github.com/Haoming02/sd-webui-forge-classic
-cd sd-webui-forge-classic/docker
+git clone https://github.com/Haoming02/sd-webui-forge-classic sd-webui-forge-neo --branch neo
+cd sd-webui-forge-neo/docker
 docker build -t forge-neo-local .
 ```
 
-To target a different CUDA variant:
-```bash
-docker build --build-arg TORCH_INDEX=cu124 -t forge-neo-local .
-```
-
----
+<hr>
 
 ## Image details
 
-| | |
-|---|---|
-| Base | `nvidia/cuda:12.6.1-runtime-ubuntu22.04` |
-| Python | 3.13 via uv |
-| PyTorch | Latest stable from `download.pytorch.org/whl/cu126` |
-| User | `forge` (UID 99 / GID 100) |
-| Port | 7860 |
+<table>
+	<tr>
+		<td>Base</td>
+		<td><code>nvidia/cuda:12.6.3-runtime-ubuntu22.04</code></td>
+	</tr>
+	<tr>
+		<td>Python</td>
+		<td><code>3.13</code> via <b>uv</b></td>
+	</tr>
+	<tr>
+		<td>PyTorch</td>
+		<td>Latest (<code>cu126</code>)</td>
+	</tr>
+	<tr>
+		<td>User</td>
+		<td><code>forge</code> (UID 99 / GID 100)</td>
+	</tr>
+	<tr>
+		<td>Port</td>
+		<td>7860</td>
+	</tr>
+</table>
 
-**First-start note:** On the first run `prepare_environment()` installs gradio, requirements, and any other dependencies. This may take a few minutes. Packages persist in the container's writable layer across restarts; recreating the container (e.g. on image update) will repeat this step once.
+> [!Note]
+> On the first run, `prepare_environment()` will install requirements and dependencies. This may take a few minutes

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,15 +2,14 @@
 
 Docker image for [sd-webui-forge-classic (neo branch)](https://github.com/Haoming02/sd-webui-forge-classic/tree/neo) by Haoming02.
 
-**Docker Hub:** `oromis95/sd-forge-neo`
+**Docker Hub:** `oromis995/sd-forge-neo`
 
 > ⚠ Requires an NVIDIA GPU. The application cannot run without one.
-> ⚠ Ensure NVIDIA drivers are up to date (550+ recommended for CUDA 12.4).
+> ⚠ Ensure NVIDIA drivers are up to date (560+ required for CUDA 12.6).
 
 ---
 
 ## Unraid deployment
-
 
 | Container path | Purpose |
 |---|---|
@@ -19,11 +18,6 @@ Docker image for [sd-webui-forge-classic (neo branch)](https://github.com/Haomin
 | `/home/forge/sd-webui/extensions` | User-installed extensions |
 
 The container runs as UID 99 / GID 100 (`nobody:users`) to match Unraid's default share permissions.
-
-Default `COMMANDLINE_ARGS`:
-```
---api --listen --cuda-malloc --xformers --skip-torch-cuda-test --enable-insecure-extension-access
-```
 
 ---
 
@@ -36,9 +30,10 @@ docker run -d \
   -v /path/to/models:/home/forge/sd-webui/models \
   -v /path/to/outputs:/home/forge/sd-webui/output \
   -v /path/to/extensions:/home/forge/sd-webui/extensions \
-  -e COMMANDLINE_ARGS="--api --listen --cuda-malloc --xformers --skip-torch-cuda-test --enable-insecure-extension-access" \
   oromis995/sd-forge-neo:latest
 ```
+
+Pass extra flags via `-e COMMANDLINE_ARGS="..."` if needed (e.g. `--api`, `--xformers`, `--cuda-malloc`).
 
 Access the WebUI at `http://<host-ip>:7860`.
 
@@ -54,7 +49,7 @@ docker build -t forge-neo-local .
 
 To target a different CUDA variant:
 ```bash
-docker build --build-arg TORCH_INDEX=cu126 -t forge-neo-local .
+docker build --build-arg TORCH_INDEX=cu124 -t forge-neo-local .
 ```
 
 ---
@@ -63,11 +58,10 @@ docker build --build-arg TORCH_INDEX=cu126 -t forge-neo-local .
 
 | | |
 |---|---|
-| Base | `nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04` |
-| Python | 3.12 via uv — 3.13 has no xformers wheels |
-| PyTorch | Latest stable from `download.pytorch.org/whl/cu124` |
-| xformers | Co-installed from the PyTorch index for ABI compatibility |
+| Base | `nvidia/cuda:12.6.1-cudnn-runtime-ubuntu22.04` |
+| Python | 3.13 via uv |
+| PyTorch | Latest stable from `download.pytorch.org/whl/cu126` |
 | User | `forge` (UID 99 / GID 100) |
 | Port | 7860 |
 
-**First-start note:** On the first run `prepare_environment()` installs gradio (version-pinned internally by Forge) and a small number of extension packages. These persist in the container's writable layer across restarts. Recreating the container (e.g. on image update) will repeat this step once.
+**First-start note:** On the first run `prepare_environment()` installs gradio, requirements, and any other dependencies. This may take a few minutes. Packages persist in the container's writable layer across restarts; recreating the container (e.g. on image update) will repeat this step once.

--- a/docker/README.md
+++ b/docker/README.md
@@ -16,6 +16,7 @@ Docker image for [sd-webui-forge-classic (neo branch)](https://github.com/Haomin
 | `/home/forge/sd-webui/models` | Checkpoints, VAEs, LoRAs, ControlNet weights |
 | `/home/forge/sd-webui/output` | Generated images |
 | `/home/forge/sd-webui/extensions` | User-installed extensions |
+| `/home/forge/sd-webui/config` | Settings (`config.json`, `ui-config.json`, `styles.csv`, etc.) |
 
 The container runs as UID 99 / GID 100 (`nobody:users`) to match Unraid's default share permissions.
 
@@ -30,6 +31,7 @@ docker run -d \
   -v /path/to/models:/home/forge/sd-webui/models \
   -v /path/to/outputs:/home/forge/sd-webui/output \
   -v /path/to/extensions:/home/forge/sd-webui/extensions \
+  -v /path/to/config:/home/forge/sd-webui/config \
   oromis995/sd-forge-neo:latest
 ```
 
@@ -58,7 +60,7 @@ docker build --build-arg TORCH_INDEX=cu124 -t forge-neo-local .
 
 | | |
 |---|---|
-| Base | `nvidia/cuda:12.6.1-cudnn-runtime-ubuntu22.04` |
+| Base | `nvidia/cuda:12.6.1-runtime-ubuntu22.04` |
 | Python | 3.13 via uv |
 | PyTorch | Latest stable from `download.pytorch.org/whl/cu126` |
 | User | `forge` (UID 99 / GID 100) |

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,7 +3,6 @@
 Docker image for [sd-webui-forge-classic (neo branch)](https://github.com/Haoming02/sd-webui-forge-classic/tree/neo) by Haoming02.
 
 **Docker Hub:** `oromis95/sd-forge-neo`
-**GitHub:** https://github.com/Haoming02/sd-webui-forge-classic
 
 > ⚠ Requires an NVIDIA GPU. The application cannot run without one.
 > ⚠ Ensure NVIDIA drivers are up to date (550+ recommended for CUDA 12.4).
@@ -12,7 +11,6 @@ Docker image for [sd-webui-forge-classic (neo branch)](https://github.com/Haomin
 
 ## Unraid deployment
 
-Import `sd-forge-neo.xml` from this repo into Unraid's Docker template manager.
 
 | Container path | Purpose |
 |---|---|
@@ -49,7 +47,7 @@ Access the WebUI at `http://<host-ip>:7860`.
 ## Building locally
 
 ```bash
-git clone https://github.com/Haoming02/sd-webui-forge-classic
+git clone --branch neo https://github.com/Haoming02/sd-webui-forge-classic
 cd sd-webui-forge-classic/docker
 docker build -t forge-neo-local .
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,7 +3,7 @@
 Docker image for [sd-webui-forge-classic (neo branch)](https://github.com/Haoming02/sd-webui-forge-classic/tree/neo) by Haoming02.
 
 **Docker Hub:** `oromis95/sd-forge-neo`
-**GitHub:** https://github.com/oromis995/Forge-Neo-Docker
+**GitHub:** https://github.com/Haoming02/sd-webui-forge-classic
 
 > ⚠ Requires an NVIDIA GPU. The application cannot run without one.
 > ⚠ Ensure NVIDIA drivers are up to date (550+ recommended for CUDA 12.4).
@@ -49,8 +49,8 @@ Access the WebUI at `http://<host-ip>:7860`.
 ## Building locally
 
 ```bash
-git clone https://github.com/oromis995/Forge-Neo-Docker
-cd Forge-Neo-Docker
+git clone https://github.com/Haoming02/sd-webui-forge-classic
+cd sd-webui-forge-classic/docker
 docker build -t forge-neo-local .
 ```
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,75 @@
+# SD-WebUI Forge Neo (Docker)
+
+Docker image for [sd-webui-forge-classic (neo branch)](https://github.com/Haoming02/sd-webui-forge-classic/tree/neo) by Haoming02.
+
+**Docker Hub:** `oromis95/sd-forge-neo`
+**GitHub:** https://github.com/oromis995/Forge-Neo-Docker
+
+> ⚠ Requires an NVIDIA GPU. The application cannot run without one.
+> ⚠ Ensure NVIDIA drivers are up to date (550+ recommended for CUDA 12.4).
+
+---
+
+## Unraid deployment
+
+Import `sd-forge-neo.xml` from this repo into Unraid's Docker template manager.
+
+| Container path | Purpose |
+|---|---|
+| `/home/forge/sd-webui/models` | Checkpoints, VAEs, LoRAs, ControlNet weights |
+| `/home/forge/sd-webui/output` | Generated images |
+| `/home/forge/sd-webui/extensions` | User-installed extensions |
+
+The container runs as UID 99 / GID 100 (`nobody:users`) to match Unraid's default share permissions.
+
+Default `COMMANDLINE_ARGS`:
+```
+--api --listen --cuda-malloc --xformers --skip-torch-cuda-test --enable-insecure-extension-access
+```
+
+---
+
+## Manual docker run
+
+```bash
+docker run -d \
+  --gpus all \
+  -p 7860:7860 \
+  -v /path/to/models:/home/forge/sd-webui/models \
+  -v /path/to/outputs:/home/forge/sd-webui/output \
+  -v /path/to/extensions:/home/forge/sd-webui/extensions \
+  -e COMMANDLINE_ARGS="--api --listen --cuda-malloc --xformers --skip-torch-cuda-test --enable-insecure-extension-access" \
+  oromis995/sd-forge-neo:latest
+```
+
+Access the WebUI at `http://<host-ip>:7860`.
+
+---
+
+## Building locally
+
+```bash
+git clone https://github.com/oromis995/Forge-Neo-Docker
+cd Forge-Neo-Docker
+docker build -t forge-neo-local .
+```
+
+To target a different CUDA variant:
+```bash
+docker build --build-arg TORCH_INDEX=cu126 -t forge-neo-local .
+```
+
+---
+
+## Image details
+
+| | |
+|---|---|
+| Base | `nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04` |
+| Python | 3.12 via uv — 3.13 has no xformers wheels |
+| PyTorch | Latest stable from `download.pytorch.org/whl/cu124` |
+| xformers | Co-installed from the PyTorch index for ABI compatibility |
+| User | `forge` (UID 99 / GID 100) |
+| Port | 7860 |
+
+**First-start note:** On the first run `prepare_environment()` installs gradio (version-pinned internally by Forge) and a small number of extension packages. These persist in the container's writable layer across restarts. Recreating the container (e.g. on image update) will repeat this step once.

--- a/docker/README.md
+++ b/docker/README.md
@@ -37,6 +37,16 @@
 
 <hr>
 
+## Pre-built Image
+
+A pre-built image with this code is maintained on Docker Hub by [@oromis995](https://github.com/oromis995):
+
+```bash
+docker pull oromis995/sd-forge-neo:latest
+```
+
+<hr>
+
 ## Building Locally
 
 ```bash

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -euo pipefail
+
+# TCMalloc reduces memory fragmentation under large model workloads.
+export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4
+
+# Detect whether a CUDA-capable GPU is accessible at runtime.
+if python -c "import torch; exit(0 if torch.cuda.is_available() else 1)" 2>/dev/null; then
+    HAS_CUDA=true
+else
+    HAS_CUDA=false
+    echo "[entrypoint] No CUDA GPU detected — running in CPU mode."
+fi
+
+# Read COMMANDLINE_ARGS then unset it — launch.py also reads this env var,
+# so leaving it set causes every flag to appear twice in the final args list.
+RAW_ARGS="${COMMANDLINE_ARGS:-}"
+unset COMMANDLINE_ARGS
+
+EXTRA_ARGS=()
+if [[ -n "$RAW_ARGS" ]]; then
+    read -ra EXTRA_ARGS <<< "$RAW_ARGS"
+fi
+
+# When running without CUDA, bypass the GPU check and drop GPU-only flags.
+if [[ "$HAS_CUDA" == "false" ]]; then
+    FILTERED=("--skip-torch-cuda-test")
+    for arg in "${EXTRA_ARGS[@]}"; do
+        case "$arg" in
+            --cuda-malloc|--xformers)
+                echo "[entrypoint] Dropping GPU-only flag: $arg" ;;
+            *)
+                FILTERED+=("$arg") ;;
+        esac
+    done
+    EXTRA_ARGS=("${FILTERED[@]}")
+fi
+
+exec python /home/forge/sd-webui/launch.py \
+    --listen \
+    --port "${FORGE_PORT:-7860}" \
+    --skip-python-version-check \
+    "${EXTRA_ARGS[@]}" \
+    "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -36,6 +36,12 @@ if [[ "$HAS_CUDA" == "false" ]]; then
     EXTRA_ARGS=("${FILTERED[@]}")
 fi
 
+# Symlink settings files into the config bind-mount so they persist across
+# container recreations. The app writes through the symlinks to the volume.
+for f in config.json ui-config.json styles.csv params.txt user.css; do
+    ln -sf /home/forge/sd-webui/config/$f /home/forge/sd-webui/$f
+done
+
 exec python /home/forge/sd-webui/launch.py \
     --listen \
     --port "${FORGE_PORT:-7860}" \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,19 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-# TCMalloc reduces memory fragmentation under large model workloads.
+# TCMalloc reduces memory fragmentation under large model workloads
 export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4
 
-# Detect whether a CUDA-capable GPU is accessible at runtime.
-if python -c "import torch; exit(0 if torch.cuda.is_available() else 1)" 2>/dev/null; then
-    HAS_CUDA=true
-else
-    HAS_CUDA=false
-    echo "[entrypoint] No CUDA GPU detected — running in CPU mode."
-fi
-
-# Read COMMANDLINE_ARGS then unset it — launch.py also reads this env var,
-# so leaving it set causes every flag to appear twice in the final args list.
+# Read COMMANDLINE_ARGS then unset it
 RAW_ARGS="${COMMANDLINE_ARGS:-}"
 unset COMMANDLINE_ARGS
 
@@ -22,29 +13,12 @@ if [[ -n "$RAW_ARGS" ]]; then
     read -ra EXTRA_ARGS <<< "$RAW_ARGS"
 fi
 
-# When running without CUDA, bypass the GPU check and drop GPU-only flags.
-if [[ "$HAS_CUDA" == "false" ]]; then
-    FILTERED=("--skip-torch-cuda-test")
-    for arg in "${EXTRA_ARGS[@]}"; do
-        case "$arg" in
-            --cuda-malloc|--xformers)
-                echo "[entrypoint] Dropping GPU-only flag: $arg" ;;
-            *)
-                FILTERED+=("$arg") ;;
-        esac
-    done
-    EXTRA_ARGS=("${FILTERED[@]}")
-fi
-
-# Symlink settings files into the config bind-mount so they persist across
-# container recreations. The app writes through the symlinks to the volume.
-for f in config.json ui-config.json styles.csv params.txt user.css; do
+# Symlink settings files into the config bind-mount so they persist across container recreations
+for f in config.json ui-config.json styles.csv user.css; do
     ln -sf /home/forge/sd-webui/config/$f /home/forge/sd-webui/$f
 done
 
 exec python /home/forge/sd-webui/launch.py \
     --listen \
-    --port "${FORGE_PORT:-7860}" \
-    --skip-python-version-check \
     "${EXTRA_ARGS[@]}" \
     "$@"


### PR DESCRIPTION
## Summary

- Adds a `docker/` folder with a self-contained Docker setup for running the neo branch on Linux with an NVIDIA GPU
- Targets Unraid deployments (UID 99 / GID 100) but works with any standard `docker run --gpus all` setup
- Uses `uv` + Python 3.12 (3.13 has no xformers wheels), CUDA 12.4, and co-installs xformers from the PyTorch index for ABI compatibility
- Entrypoint detects GPU availability at runtime and drops incompatible flags automatically

## Files

- `docker/Dockerfile` — image definition
- `docker/entrypoint.sh` — runtime entry point
- `docker/.dockerignore` — build context exclusions
- `docker/README.md` — usage and image details

## Test plan

- [x] Built and run on Linux with NVIDIA RTX 3060 (CUDA 12.4, driver 550+)
- [x] WebUI accessible at port 7860
- [x] xformers cross-attention active
- [x] Models, outputs, and extensions mount correctly via bind volumes