### PR TITLE
Fix Flux model detection for newer checkpoints

### DIFF
--- a/backend/loader.py
+++ b/backend/loader.py
@@ -484,6 +484,7 @@ def replace_state_dict(sd: dict[str, torch.Tensor], asd: dict[str, torch.Tensor]
 
     ##  identify model type
     flux_test_key = "model.diffusion_model.double_blocks.0.img_attn.norm.key_norm.scale"
+    flux_test_key_weight = "model.diffusion_model.double_blocks.0.img_attn.norm.key_norm.weight"
     svdq_test_key = "model.diffusion_model.single_transformer_blocks.0.mlp_fc1.qweight"
     legacy_test_key = "model.diffusion_model.input_blocks.4.1.transformer_blocks.0.attn2.to_k.weight"
 
@@ -496,7 +497,7 @@ def replace_state_dict(sd: dict[str, torch.Tensor], asd: dict[str, torch.Tensor]
                 model_type = "xlrf"  # sdxl refiner model
             case 2048:
                 model_type = "sdxl"
-    elif flux_test_key in sd or svdq_test_key in sd:
+    elif flux_test_key in sd or flux_test_key_weight in sd or svdq_test_key in sd:
         model_type = "flux"
 
     ##  prefixes used by various model types for CLIP-L


### PR DESCRIPTION
**Description:**

Newer Flux checkpoint exports (circa early 2026) use `key_norm.weight` for RMSNorm layers instead of the older `key_norm.scale` naming. The model type detector in `replace_state_dict` only checked for the `scale` variant, causing newer checkpoints to fail detection (`model_type` staying `"-"`), which meant the CLIP-L prefix resolved to `None` and no CLIP keys were merged from external text encoder files — ultimately hitting the `AssertionError: You do not have CLIP state dict!` in `load_huggingface_component`. Older checkpoints using `key_norm.scale` are unaffected.

**Root cause:**

In `replace_state_dict` (loader.py), the Flux detection key is hardcoded:

```python
flux_test_key = "model.diffusion_model.double_blocks.0.img_attn.norm.key_norm.scale"
```

Newer checkpoints use `weight` instead of `scale` for this tensor, so the detection falls through and `model_type` is never set to `"flux"`.

**Fix:**

Add the alternative key name to the detection check:

```python
flux_test_key = "model.diffusion_model.double_blocks.0.img_attn.norm.key_norm.scale"
flux_test_key_weight = "model.diffusion_model.double_blocks.0.img_attn.norm.key_norm.weight"
svdq_test_key = "model.diffusion_model.single_transformer_blocks.0.mlp_fc1.qweight"

# ...

elif flux_test_key in sd or flux_test_key_weight in sd or svdq_test_key in sd:
    model_type = "flux"
```

**Testing:**

Verified that a Flux checkpoint using `key_norm.weight` (previously failing with `AssertionError: You do not have CLIP state dict!`) loads and generates correctly after this change, with external `clip_l.safetensors`, `t5xxl_fp16.safetensors`, and `ae.safetensors` modules. Below are two models that can be used for before and after testing of the proposed code fix though this issue is present in most newer `Flux.1 D` checkpoints found on Civitai.

Example older checkpoint: https://civitai.com/models/847101?modelVersionId=2852426
Example newer checkpoint: https://civitai.com/models/847101?modelVersionId=2359335

P.S. I used Claude to debug the issue and write up most of this PR.