### PR TITLE
Make AMD GPU (ROCm) the default backend

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -89,7 +89,7 @@ def run(command, desc=None, errdesc=None, custom_env=None, live: bool = default_
 
 
 def _torch_version() -> tuple[str, str]:
-    """Given `2.10.0.dev20251111+cu130` ; Return `("2.10.0", "cu130")`"""
+    """Given `2.9.1+rocm6.4` ; Return `("2.9.1", "rocm6.4")`"""
     import importlib.metadata
 
     ver = importlib.metadata.version("torch")
@@ -97,7 +97,7 @@ def _torch_version() -> tuple[str, str]:
 
     if m is None:
         print("\n\nFailed to parse PyTorch version...")
-        ver = os.environ.get("PYTORCH_VERSION", "2.10.0+cu130")
+        ver = os.environ.get("PYTORCH_VERSION", "2.9.1+rocm6.4")
         print("Assuming: ", ver)
         print('(you can change this with `export PYTORCH_VERSION="..."`)\n\n')
         m = re.search(r"(\d+\.\d+\.\d+)(?:[^+]+)?\+(.+)", ver)
@@ -286,8 +286,10 @@ def requirements_met(requirements_file):
 
 
 def prepare_environment():
-    torch_index_url = os.environ.get("TORCH_INDEX_URL", "https://download.pytorch.org/whl/cu130")
-    torch_command = os.environ.get("TORCH_COMMAND", f"pip install torch==2.11.0+cu130 torchvision==0.26.0+cu130 --extra-index-url {torch_index_url}")
+    # Defaults target AMD GPUs via ROCm 6.4. Override TORCH_INDEX_URL / TORCH_COMMAND
+    # in webui-user.sh to use a different backend (e.g. CUDA, CPU, or older ROCm).
+    torch_index_url = os.environ.get("TORCH_INDEX_URL", "https://download.pytorch.org/whl/rocm6.4")
+    torch_command = os.environ.get("TORCH_COMMAND", f"pip install torch==2.9.1+rocm6.4 torchvision==0.24.1+rocm6.4 --index-url {torch_index_url}")
     xformers_package = os.environ.get("XFORMERS_PACKAGE", f"xformers==0.0.35 --extra-index-url {torch_index_url}")
     bnb_package = os.environ.get("BNB_PACKAGE", "bitsandbytes==0.49.2")
 
@@ -317,6 +319,9 @@ def prepare_environment():
         startup_timer.record("install torch")
 
     if not args.skip_torch_cuda_test:
+        # PyTorch's ROCm build exposes the AMD HIP runtime through the
+        # `torch.cuda` namespace, so this single check covers NVIDIA (CUDA),
+        # AMD (ROCm/HIP), Intel (XPU), and Apple Silicon (MPS) backends.
         TORCH_CHECK: str = """
 import torch
 cuda = hasattr(torch, "cuda") and torch.cuda.is_available()
@@ -327,9 +332,18 @@ assert cuda or xpu or mps
 
         success, err = check_run_python(TORCH_CHECK, return_error=True)
         if not success:
-            if "older driver" in str(err).lower():
-                raise SystemError("Please update your GPU driver to support cu130 ; or manually install older PyTorch")
-            raise RuntimeError("PyTorch is not able to access GPU")
+            err_text = str(err).lower()
+            if "older driver" in err_text:
+                raise SystemError(
+                    "Please update your GPU driver to a version that supports the installed PyTorch build, "
+                    "or override TORCH_COMMAND in webui-user.sh to install an older PyTorch."
+                )
+            raise RuntimeError(
+                "PyTorch is not able to access GPU. "
+                "For AMD GPUs make sure ROCm is installed on the host and that your card's "
+                "gfx target is supported by the torch+rocm wheel; you may need to set "
+                "HSA_OVERRIDE_GFX_VERSION (see webui-user.sh)."
+            )
         startup_timer.record("torch GPU test")
 
     if not is_installed("packaging"):

--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -322,27 +322,49 @@ def prepare_environment():
         # PyTorch's ROCm build exposes the AMD HIP runtime through the
         # `torch.cuda` namespace, so this single check covers NVIDIA (CUDA),
         # AMD (ROCm/HIP), Intel (XPU), and Apple Silicon (MPS) backends.
+        # We print backend-identifying info to stderr so failures are diagnosable.
         TORCH_CHECK: str = """
-import torch
+import sys, torch
+hip = getattr(torch.version, "hip", None)
+cu  = getattr(torch.version, "cuda", None)
+print(f"torch={torch.__version__}  cuda_build={cu}  hip_build={hip}", file=sys.stderr)
 cuda = hasattr(torch, "cuda") and torch.cuda.is_available()
 xpu = hasattr(torch, "xpu") and torch.xpu.is_available()
 mps = hasattr(torch, "mps") and torch.mps.is_available()
+print(f"is_available: cuda/hip={cuda} xpu={xpu} mps={mps}", file=sys.stderr)
+if cuda:
+    try:
+        n = torch.cuda.device_count()
+        print(f"device_count={n}", file=sys.stderr)
+        for i in range(n):
+            print(f"  [{i}] {torch.cuda.get_device_name(i)}", file=sys.stderr)
+    except Exception as e:
+        print(f"device enumeration failed: {e!r}", file=sys.stderr)
 assert cuda or xpu or mps
         """
 
         success, err = check_run_python(TORCH_CHECK, return_error=True)
         if not success:
-            err_text = str(err).lower()
-            if "older driver" in err_text:
+            err_text = err.decode("utf-8", errors="ignore") if isinstance(err, (bytes, bytearray)) else str(err)
+            print("\n--- GPU detection output ---", file=sys.stderr)
+            print(err_text, file=sys.stderr)
+            print("--- end GPU detection output ---\n", file=sys.stderr)
+
+            low = err_text.lower()
+            if "older driver" in low:
                 raise SystemError(
                     "Please update your GPU driver to a version that supports the installed PyTorch build, "
                     "or override TORCH_COMMAND in webui-user.sh to install an older PyTorch."
                 )
             raise RuntimeError(
-                "PyTorch is not able to access GPU. "
-                "For AMD GPUs make sure ROCm is installed on the host and that your card's "
-                "gfx target is supported by the torch+rocm wheel; you may need to set "
-                "HSA_OVERRIDE_GFX_VERSION (see webui-user.sh)."
+                "PyTorch is not able to access GPU. For AMD GPUs verify the host setup:\n"
+                "  1. ROCm runtime is installed on the host (e.g. `rocminfo` succeeds and lists your GPU).\n"
+                "  2. Your user is in the `render` and `video` groups (`sudo usermod -aG render,video $USER` then re-login).\n"
+                "  3. /dev/kfd and /dev/dri/* exist and are accessible to your user.\n"
+                "  4. Your card's gfx target is supported by torch+rocm6.4. If unsupported, export\n"
+                "     HSA_OVERRIDE_GFX_VERSION in webui-user.sh to the closest supported arch\n"
+                "     (e.g. 11.0.0 for RDNA3, 10.3.0 for RDNA2).\n"
+                "See the `--- GPU detection output ---` block above for the underlying error."
             )
         startup_timer.record("torch GPU test")
 

--- a/webui-user.sh
+++ b/webui-user.sh
@@ -4,7 +4,24 @@
 # export GIT=
 # export VENV_DIR=
 
-export TORCH_COMMAND="pip install torch==2.10.0 torchvision==0.25.0"
+# AMD GPU (ROCm) defaults.
+# These wheels are published by PyTorch at https://download.pytorch.org/whl/rocm6.4/
+# torch 2.9.1+rocm6.4 and torchvision 0.24.1+rocm6.4 are the latest stable
+# pair for Python 3.13 on linux_x86_64.
+export TORCH_INDEX_URL="https://download.pytorch.org/whl/rocm6.4"
+export TORCH_COMMAND="pip install torch==2.9.1+rocm6.4 torchvision==0.24.1+rocm6.4 --index-url ${TORCH_INDEX_URL}"
+
+# Tell ROCm/HIP which GPU architecture to target if your card isn't auto-detected.
+# Uncomment and set to match your hardware. Common values:
+#   RDNA 3  (RX 7000 / W7000):  11.0.0   (gfx1100/1101/1102)
+#   RDNA 2  (RX 6000 / W6000):  10.3.0   (gfx1030/1031/1032)
+#   CDNA 2  (MI200 series):     leave unset; gfx90a is auto-detected
+#   CDNA 3  (MI300 series):     leave unset; gfx942 is auto-detected
+# export HSA_OVERRIDE_GFX_VERSION=11.0.0
+
+# If you have multiple GPUs, pick which one PyTorch should use:
+# export HIP_VISIBLE_DEVICES=0
+# export ROCR_VISIBLE_DEVICES=0
 
 export COMMANDLINE_ARGS="--uv"
 


### PR DESCRIPTION
Previous defaults pointed at non-existent torch==2.10.0/2.11.0+cu130 wheels and a CUDA-only index URL, which made fresh installs fail with "PyTorch is not able to access GPU" on AMD hardware.

- webui-user.sh: install torch 2.9.1+rocm6.4 and torchvision 0.24.1+rocm6.4 from https://download.pytorch.org/whl/rocm6.4 (verified to exist for cp313 linux_x86_64), with HSA_OVERRIDE_GFX_VERSION / HIP_VISIBLE_DEVICES hints commented for users to enable per their card.
- modules/launch_utils.py: align prepare_environment() defaults with the ROCm wheels, update _torch_version() fallback, and reword the GPU-test failure message to mention ROCm/HSA_OVERRIDE_GFX_VERSION instead of cu130.