### PR TITLE
Improve compatibility with portable Python runtimes

### DIFF
--- a/extensions-builtin/forge_legacy_preprocessors/install.py
+++ b/extensions-builtin/forge_legacy_preprocessors/install.py
@@ -1,5 +1,7 @@
-import os
+import os, sys
+
 from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 from modules.errors import display
 
 import launch

--- a/launch.py
+++ b/launch.py
@@ -1,3 +1,6 @@
+import os, sys
+sys.path.insert(0, os.path.dirname(__file__))
+
 from modules import launch_utils
 
 args = launch_utils.args

--- a/webui.py
+++ b/webui.py
@@ -1,8 +1,9 @@
 if __name__ == "__main__":
     raise SystemError("Call launch.py instead")
 
+import os, sys
+sys.path.insert(0, os.path.dirname(__file__))
 
-import os
 import time
 from threading import Thread
 


### PR DESCRIPTION
This fixes module import issues when running Forge with portable Python runtimes.
<img width="1102" height="253" alt="Screenshot 2026-05-21 113208" src="https://github.com/user-attachments/assets/55141cb8-9a3d-4cf3-a0c4-561d0273d5bb" />

It also improves compatibility with portable/self-contained distributions
similar to ComfyUI setups.
For Example
<img width="972" height="414" alt="Screenshot 2026-05-21 110347" src="https://github.com/user-attachments/assets/89bfc876-f0fe-4c26-a0d3-cec8947ee94e" />

This issue also affects such as sd-hub,
which may require a similar explicit path resolution fix:

sys.path.insert(0, str(Path(__file__).resolve().parents[2]))

(A more centralized fix may be preferable long term.)