### PR TITLE
Allow mp4/webm as extra_network preview images

### DIFF
--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -19,7 +19,7 @@ from modules.infotext_utils import image_from_url_text
 
 extra_pages = []
 allowed_dirs = set()
-default_allowed_preview_extensions = ["png", "jpg", "jpeg", "webp", "gif"]
+default_allowed_preview_extensions = ["png", "jpg", "jpeg", "webp", "gif", "mp4", "webm"]
 
 @functools.cache
 def allowed_preview_extensions_with_extra(extra_extensions=None):
@@ -262,7 +262,14 @@ class ExtraNetworksPage:
         style_width = f"width: {shared.opts.extra_networks_card_width}px;" if shared.opts.extra_networks_card_width else ''
         style_font_size = f"font-size: {shared.opts.extra_networks_card_text_scale*100}%;"
         card_style = style_height + style_width + style_font_size
-        background_image = f'<img src="{html.escape(preview)}" class="preview" loading="lazy">' if preview else ''
+        background_image = ''
+
+        if preview:
+            _, preview_format = os.path.splitext(preview.rsplit("&mtime=", 1)[0])
+            if preview_format.lower() in (".mp4", ".webm"):
+                background_image = f'<video src="{html.escape(preview)}" class="preview" loading="lazy" autoplay loop muted playsinline></video>'
+            else:
+                background_image = f'<img src="{html.escape(preview)}" class="preview" loading="lazy">'
 
         onclick = item.get("onclick", None)
         if onclick is None:  # Textual Inversion / LoRA

--- a/modules/ui_extra_networks_user_metadata.py
+++ b/modules/ui_extra_networks_user_metadata.py
@@ -78,16 +78,16 @@ class UserMetadataEditor:
             preview_url = self.page.find_preview(filename)
             item["preview"] = preview_url
 
-        if preview_url:
-            preview = f'''
-            <div class='card standalone-card-preview'>
-                <img src="{html.escape(preview_url)}" class="preview">
-            </div>
-            '''
-        else:
-            preview = "<div class='card standalone-card-preview'></div>"
+        preview = ""
 
-        return preview
+        if preview_url:
+            _, preview_format = os.path.splitext(preview_url.rsplit("&mtime=", 1)[0])
+            if preview_format.lower() in (".mp4", ".webm"):
+                preview = f'<video src="{html.escape(preview_url)}" class="preview" autoplay loop muted playsinline></video>'
+            else:
+                preview = f'<img src="{html.escape(preview_url)}" class="preview">'
+
+        return f'<div class="card standalone-card-preview">{preview}</div>'
 
     def relative_path(self, path):
         for parent_path in self.page.allowed_directories_for_previews():


### PR DESCRIPTION
Civitai uses mp4 files for its animated preview "images", and it's straightforward to allow these to be used as lora/checkpoint/embedding preview images. There are only two spots where `<img>` tags need to be replaced with `<video>` depending on file extension - one for the main UI displaying the entire array of cards, and one for the metadata editor used to display a singular card.