### PR TITLE
fix: guard device property assignment for transformers models (IP-Adapter regression)

### DIFF
--- a/backend/patcher/base.py
+++ b/backend/patcher/base.py
@@ -170,7 +170,10 @@ class ModelPatcher:
     def __init__(self, model: torch.nn.Module, load_device: torch.device, offload_device: torch.device, size: int = 0, *, current_device: torch.device = None, weight_inplace_update: bool = False):
         self.size = size
         self.model = model
-        self.model.device = current_device
+        try:
+            self.model.device = current_device
+        except AttributeError:
+            pass  # transformers models have device as a read-only property
 
         self.patches = {}
         self.backup = {}
@@ -670,7 +673,10 @@ class ModelPatcher:
                 mem_counter = self.model_size()
 
         self.model.lowvram_patch_counter += patch_counter
-        self.model.device = device_to
+        try:
+            self.model.device = device_to
+        except AttributeError:
+            pass  # transformers models have device as a read-only property
         self.model.model_loaded_weight_memory = mem_counter
         self.model.model_offload_buffer_memory = offload_buffer
         self.model.current_weight_patches_uuid = self.patches_uuid
@@ -715,7 +721,10 @@ class ModelPatcher:
 
             if device_to is not None:
                 self.model.to(device_to)
-                self.model.device = device_to
+                try:
+                    self.model.device = device_to
+                except AttributeError:
+                    pass  # transformers models have device as a read-only property
             self.model.model_loaded_weight_memory = 0
             self.model.model_offload_buffer_memory = 0
 
@@ -847,5 +856,6 @@ class ModelPatcher:
         return self.model.device
 
     def __del__(self):
-        self.unpin_all_weights()
+        if hasattr(self, 'pinned'):
+            self.unpin_all_weights()
         self.detach(unpatch_all=False)

--- a/backend/patcher/base.py
+++ b/backend/patcher/base.py
@@ -170,10 +170,7 @@ class ModelPatcher:
     def __init__(self, model: torch.nn.Module, load_device: torch.device, offload_device: torch.device, size: int = 0, *, current_device: torch.device = None, weight_inplace_update: bool = False):
         self.size = size
         self.model = model
-        try:
-            self.model.device = current_device
-        except AttributeError:
-            pass  # transformers models have device as a read-only property
+        self.current_device = current_device or offload_device
 
         self.patches = {}
         self.backup = {}
@@ -673,10 +670,7 @@ class ModelPatcher:
                 mem_counter = self.model_size()
 
         self.model.lowvram_patch_counter += patch_counter
-        try:
-            self.model.device = device_to
-        except AttributeError:
-            pass  # transformers models have device as a read-only property
+        self.current_device = device_to
         self.model.model_loaded_weight_memory = mem_counter
         self.model.model_offload_buffer_memory = offload_buffer
         self.model.current_weight_patches_uuid = self.patches_uuid
@@ -721,10 +715,7 @@ class ModelPatcher:
 
             if device_to is not None:
                 self.model.to(device_to)
-                try:
-                    self.model.device = device_to
-                except AttributeError:
-                    pass  # transformers models have device as a read-only property
+                self.current_device = device_to
             self.model.model_loaded_weight_memory = 0
             self.model.model_offload_buffer_memory = 0
 
@@ -849,13 +840,8 @@ class ModelPatcher:
         return self.model
 
     def current_loaded_device(self):
-        return self.model.device
-
-    @property
-    def current_device(self) -> torch.device:
-        return self.model.device
+        return self.current_device
 
     def __del__(self):
-        if hasattr(self, 'pinned'):
-            self.unpin_all_weights()
+        self.unpin_all_weights()
         self.detach(unpatch_all=False)


### PR DESCRIPTION
### Problem

Commit `1c4d3b3` ("improve LoRA loading") reintroduced a bug previously fixed in #644 (commit `d003951`).

`ModelPatcher.__init__` assigns `self.model.device = current_device`, but HuggingFace `CLIPVisionModelWithProjection` defines `device` as a read-only `@property` (no setter). This causes `AttributeError` and completely breaks IP-Adapter (FaceID, CLIP-H, etc.).

### Cascading errors
- `ModelPatcher.__del__` -> `AttributeError: 'ModelPatcher' has no attribute 'pinned'` (because `__init__` failed before `self.pinned = set()`)
- `controlnet.py` → `KeyError: 0` (params never registered)

### Fix

- Wrapped `self.model.device = ...` at 3 locations with `try/except AttributeError`
- Added `hasattr(self, 'pinned')` guard in `__del__`

This is safe because `current_loaded_device()` and `current_device` property already read via `self.model.device` (the transformers getter returns the correct value from model parameters).

### Tested
- IP-Adapter FaceID plusv2 with InsightFace+CLIP-H: working
- Regular txt2img without ControlNet: working


***Note: If deemed appropriate by maintainers, a warning log can be added inside the except block.***