### PR TITLE
Container update on pull

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,9 +36,10 @@ RUN groupadd -g 100 users 2>/dev/null || true \
 
 WORKDIR /home/forge/sd-webui
 
-# Clone at build time
-# Bust the cache below whenever upstream neo moves
+# Invalidate the cache when upstream (Neo) updates
 ADD https://api.github.com/repos/Haoming02/sd-webui-forge-classic/commits/neo /tmp/neo-rev.json
+
+# Clone at build time
 RUN git clone --branch neo --depth 1 --filter blob:none \
         https://github.com/Haoming02/sd-webui-forge-classic.git . \
     && chown -R 99:100 /home/forge

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,6 +37,8 @@ RUN groupadd -g 100 users 2>/dev/null || true \
 WORKDIR /home/forge/sd-webui
 
 # Clone at build time
+# Bust the cache below whenever upstream neo moves
+ADD https://api.github.com/repos/Haoming02/sd-webui-forge-classic/commits/neo /tmp/neo-rev.json
 RUN git clone --branch neo --depth 1 --filter blob:none \
         https://github.com/Haoming02/sd-webui-forge-classic.git . \
     && chown -R 99:100 /home/forge


### PR DESCRIPTION
I wrote a CI/CD pipeline to have a testing release update automatically every time you update. Did not add it in your code to avoid polluting your repo, but it's in use by me. It only updates with your changes. If I ever change anything, I'll make a PR, like now. This PR adds two things, a force pull of the container will now also update your code, unlike previously, and a docker ReadMe addition specific to Unraid, which I have yet to commit.