### PR TITLE
fix: preset switch no longer wipes checkpoint and modules

### DIFF
--- a/modules_forge/main_entry.py
+++ b/modules_forge/main_entry.py
@@ -140,6 +140,10 @@ def refresh_model_loading_parameters(*, refresh: bool = True):
 def checkpoint_change(ckpt_name: str, preset: str, save=True, refresh=True) -> bool:
     """`ckpt_name` accepts valid aliases; returns `True` if checkpoint changed"""
     new_ckpt_info = sd_models.get_closet_checkpoint_match(ckpt_name)
+    if new_ckpt_info is None:
+        # never let an empty / unresolvable dropdown wipe the saved checkpoint
+        return False
+
     current_ckpt_info = sd_models.get_closet_checkpoint_match(getattr(shared.opts, "sd_model_checkpoint", ""))
     if new_ckpt_info == current_ckpt_info:
         return False
@@ -283,11 +287,19 @@ def on_preset_change(preset: str):
     batch_args_i2i = batch_args_t2i.copy()
     batch_args_i2i["value"] = getattr(shared.opts, f"{preset}_i2i_batch_size", 1)
 
+    # These options are registered with empty defaults (`None` / `[]`), so a preset that has
+    # never been configured reads back as blank. Blank must mean "inherit what is loaded now",
+    # otherwise switching to a fresh preset wipes the checkpoint and the VAE / text encoders,
+    # leaving a model that cannot load at all.
+    preset_ckpt = getattr(shared.opts, f"forge_checkpoint_{preset}", None) or shared.opts.sd_model_checkpoint
+    preset_modules = getattr(shared.opts, f"forge_additional_modules_{preset}", None) or getattr(shared.opts, "forge_additional_modules", [])
+    preset_dtype = getattr(shared.opts, f"forge_unet_storage_dtype_{preset}", None) or "Automatic"
+
     return [
         # ui_checkpoint, ui_vae, ui_forge_unet_dtype
-        gr.update(value=getattr(shared.opts, f"forge_checkpoint_{preset}", shared.opts.sd_model_checkpoint)),
-        gr.update(value=[os.path.basename(m) for m in getattr(shared.opts, f"forge_additional_modules_{preset}", [])]),
-        gr.update(value=getattr(shared.opts, f"forge_unet_storage_dtype_{preset}", "Automatic")),
+        gr.update(value=preset_ckpt),
+        gr.update(value=[os.path.basename(m) for m in preset_modules]),
+        gr.update(value=preset_dtype),
         # ui_txt2img_steps, ui_txt2img_hr_steps, ui_img2img_steps
         gr.update(value=v) if (v := getattr(shared.opts, f"{preset}_t2i_step", 20)) > 0 else gr.skip(),
         gr.update(value=v) if (v := getattr(shared.opts, f"{preset}_t2i_hr_step", 20)) > 0 else gr.skip(),


### PR DESCRIPTION
### Problem

Switching **UI Preset** to a preset that has never been configured blanks the **Checkpoint** and **VAE / Text Encoder** fields, and then persists those blanks to `config.json`. The result is a model that cannot load, and the damage survives a restart.

### Reproduction

1. Load any model and select at least one module, so `config.json` has a valid `sd_model_checkpoint` and a non-empty `forge_additional_modules`.
2. Switch **UI Preset** to a preset you have never configured (e.g. `anima` or `krea` on a fresh install).
3. Both fields go blank in the UI, and `config.json` is now written with an empty checkpoint and an empty module list.
4. Restart — the selection is gone for good, and generating fails.

### Cause

`modules_forge/presets.py` registers the per-preset options with empty defaults:

```python
f"forge_checkpoint_{name}": OptionInfo(None),
f"forge_additional_modules_{name}": OptionInfo([]),
```

`Options.__getattr__` in `modules/options.py` returns `data_labels[item].default` for any **registered** key. Because the key always resolves, the three-argument fallback in `on_preset_change` never fires:

```python
# fallback is unreachable — the key resolves to the registered default, None
gr.update(value=getattr(shared.opts, f"forge_checkpoint_{preset}", shared.opts.sd_model_checkpoint))
```

So an unconfigured preset yields `None` / `[]` rather than the intended fallback. The `.success(...)` chain then calls `_load_presets`, which passes those blanks to `checkpoint_change` / `modules_change` → `shared.opts.set(...)` → `shared.opts.save(shared.config_filename)`, committing the empty values to disk.

### Fix

- `on_preset_change`: treat a blank per-preset value as "inherit what is currently loaded", using `or` chains instead of the unreachable `getattr` fallbacks.
- `checkpoint_change`: return early when `get_closet_checkpoint_match()` cannot resolve the name, so an empty or invalid dropdown can never overwrite the saved checkpoint.

### Notes

- One file, 15 insertions / 3 deletions. No new options, no changed defaults, no behaviour change for presets that *are* configured — those still read back their own saved values.
- Verified by switching `anima → sd → anima → krea` in a browser: the checkpoint and module selection now survive every transition, where previously the first switch to an unconfigured preset wiped them.
- Possibly related, previously closed: #1291 (`sd_model_checkpoint` change not loading `forge_additional_modules`).
- Tested on Windows, Python 3.13, torch 2.11.0+cu130. `ruff format` reports no change; the only `ruff check` finding in this file (`F401` on `backend.memory_management`) is pre-existing on `neo` and left untouched as out of scope.
