### PR TITLE
Feature/Task-Queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,11 @@ The name "Forge" is inspired by "Minecraft Forge". This project aims to become t
 - [X] Support **Region** Controlnet
     - [Anima](https://huggingface.co/Sen-sou/Anima-LLLite-Regional-Controlnet)
     - use the **Region** mode to create color masks
+- [X] Implement **Task Queueing** for txt2img/img2img
+    - per-tab Queue button with count badge
+    - enqueue generations while one is running; Generate hidden until queue clears
+    - segmented Queue | Interrupt | Skip controls
+    - by default, Ctrl+Enter adds a task to the queue when running; enable "Revert [Ctrl + Enter] to only interrupt the generation (disable Task Queueing)" in Settings -> UI Alternatives to revert to only interrupting
 
 #### Removed Features
 

--- a/javascript/progressbar.js
+++ b/javascript/progressbar.js
@@ -71,6 +71,49 @@ function randomId() {
     );
 }
 
+// Tasks that are waiting for their turn, per tab. Every task gets its own progress bar,
+// and all progress bars are absolutely positioned in the same spot, so a queued task's
+// (necessarily empty) bar would cover the running task's real progress. Instead, queued
+// tasks are counted here and reported on the Queue button.
+const queuedTasks = {};
+
+function progressTabName(progressbarContainer) {
+    const id = progressbarContainer ? progressbarContainer.id : "";
+    return id ? id.split("_")[0] : null;
+}
+
+function updateQueueCount(tabname) {
+    const button = gradioApp().getElementById(tabname + "_queue");
+    if (!button) return;
+
+    const count = queuedTasks[tabname] ? queuedTasks[tabname].size : 0;
+    let badge = button.querySelector(".queue-count");
+
+    if (!count) {
+        if (badge) badge.remove();
+        return;
+    }
+
+    if (!badge) {
+        badge = document.createElement("span");
+        badge.className = "queue-count";
+        button.appendChild(badge);
+    }
+    badge.textContent = count;
+}
+
+function setTaskQueued(tabname, id_task, queued) {
+    if (!tabname) return;
+
+    if (!queuedTasks[tabname]) queuedTasks[tabname] = new Set();
+
+    const sizeBefore = queuedTasks[tabname].size;
+    if (queued) queuedTasks[tabname].add(id_task);
+    else queuedTasks[tabname].delete(id_task);
+
+    if (queuedTasks[tabname].size !== sizeBefore) updateQueueCount(tabname);
+}
+
 // starts sending progress requests to "/internal/progress" uri, creating progressbar above progressbarContainer element and
 // preview inside gallery element. Cleans up all created stuff when the task is over and calls atEnd.
 // calls onProgress every time there is a progress update
@@ -78,6 +121,7 @@ function requestProgress(id_task, progressbarContainer, gallery, atEnd, onProgre
     let dateStart = new Date();
     let wasEverActive = false;
     let parentProgressbar = progressbarContainer.parentNode;
+    let tabname = progressTabName(progressbarContainer);
     let wakeLock = null;
 
     if (gallery && gallery.classList.contains("hidden")) gallery = gallery.parentElement.querySelector(".gradio-video");
@@ -114,6 +158,7 @@ function requestProgress(id_task, progressbarContainer, gallery, atEnd, onProgre
 
     let removeProgressBar = function () {
         releaseWakeLock();
+        setTaskQueued(tabname, id_task, false);
         if (!divProgress) return;
 
         setTitle("");
@@ -134,6 +179,22 @@ function requestProgress(id_task, progressbarContainer, gallery, atEnd, onProgre
                     removeProgressBar();
                     return;
                 }
+
+                // This task is waiting behind another one, so it has no progress of its own
+                // to show yet. Keep its bar hidden so the running task's bar stays visible,
+                // and leave the title alone for the same reason.
+                if (res.queued && !res.active) {
+                    if (divProgress) divProgress.style.display = "none";
+                    setTaskQueued(tabname, id_task, true);
+
+                    setTimeout(() => {
+                        funProgress(id_task, res.id_live_preview);
+                    }, opts.live_preview_refresh_period || 500);
+                    return;
+                }
+
+                setTaskQueued(tabname, id_task, false);
+                if (divProgress) divProgress.style.display = opts.show_progressbar ? "block" : "none";
 
                 let progressText = "";
 

--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -128,9 +128,17 @@ function create_submit_args(args) {
 }
 
 function setSubmitButtonsVisibility(tabname, showInterrupt, showSkip, showInterrupting) {
-    gradioApp().getElementById(tabname + "_interrupt").style.display = showInterrupt ? "block" : "none";
-    gradioApp().getElementById(tabname + "_skip").style.display = showSkip ? "block" : "none";
-    gradioApp().getElementById(tabname + "_interrupting").style.display = showInterrupting ? "block" : "none";
+    const genBtn = gradioApp().getElementById(tabname + "_generate");
+    const queueBtn = gradioApp().getElementById(tabname + "_queue");
+    const interruptBtn = gradioApp().getElementById(tabname + "_interrupt");
+    const skipBtn = gradioApp().getElementById(tabname + "_skip");
+    const interruptingBtn = gradioApp().getElementById(tabname + "_interrupting");
+    const showControls = showInterrupt || showSkip || showInterrupting;
+    if (genBtn) genBtn.style.visibility = showControls ? "hidden" : "visible";
+    if (queueBtn) queueBtn.style.display = showControls && !showInterrupting ? "block" : "none";
+    if (interruptBtn) interruptBtn.style.display = showInterrupt ? "block" : "none";
+    if (skipBtn) skipBtn.style.display = showSkip ? "block" : "none";
+    if (interruptingBtn) interruptingBtn.style.display = showInterrupting ? "block" : "none";
 }
 
 function showSubmitButtons(tabname, show) {
@@ -148,6 +156,7 @@ function showRestoreProgressButton(tabname, show) {
 }
 
 function submit() {
+    window._txt2img_active = (window._txt2img_active || 0) + 1;
     showSubmitButtons("txt2img", false);
 
     const id = randomId();
@@ -158,9 +167,12 @@ function submit() {
         gradioApp().getElementById("txt2img_gallery_container"),
         gradioApp().getElementById("txt2img_gallery"),
         function () {
-            showSubmitButtons("txt2img", true);
-            localRemove("txt2img_task_id");
-            showRestoreProgressButton("txt2img", false);
+            window._txt2img_active = Math.max((window._txt2img_active || 1) - 1, 0);
+            if (window._txt2img_active === 0) {
+                showSubmitButtons("txt2img", true);
+                localRemove("txt2img_task_id");
+                showRestoreProgressButton("txt2img", false);
+            }
         },
     );
 
@@ -176,6 +188,7 @@ function submit_txt2img_upscale() {
 }
 
 function submit_img2img() {
+    window._img2img_active = (window._img2img_active || 0) + 1;
     showSubmitButtons("img2img", false);
 
     const id = randomId();
@@ -186,9 +199,12 @@ function submit_img2img() {
         gradioApp().getElementById("img2img_gallery_container"),
         gradioApp().getElementById("img2img_gallery"),
         function () {
-            showSubmitButtons("img2img", true);
-            localRemove("img2img_task_id");
-            showRestoreProgressButton("img2img", false);
+            window._img2img_active = Math.max((window._img2img_active || 1) - 1, 0);
+            if (window._img2img_active === 0) {
+                showSubmitButtons("img2img", true);
+                localRemove("img2img_task_id");
+                showRestoreProgressButton("img2img", false);
+            }
         },
     );
 

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -418,7 +418,7 @@ options_templates.update(
             "show_rescale_cfg": OptionInfo(False, "Display the Rescale CFG Slider").info("feature for v-pred checkpoints").needs_reload_ui(),
             "show_mahiro": OptionInfo(False, "Display the MaHiRo Toggle").info('see <a href="https://huggingface.co/spaces/yoinked/blue-arxiv">blue-arxiv</a> - <b>id:</b> <ins>2024-1208.1</ins>').needs_reload_ui(),
             "paste_safe_guard": OptionInfo(False, 'Disable the "Read generation parameters" button (↙️) when negative prompt is not empty'),
-            "ctrl_enter_interrupt": OptionInfo(False, "Revert [Ctrl + Enter] to only interrupt the generation").info('the current "intended" behavior is to interrupt the current generation then immediately start a new one'),
+            "ctrl_enter_interrupt": OptionInfo(False, "Revert [Ctrl + Enter] to only interrupt the generation (disable Task Queueing)").info('by default, [Ctrl + Enter] adds a task to the queue and will no longer interrupt the current generation; checking this disables Task Queueing and reverts to only interrupting the generation'),
             "quicksettings_accordion": OptionInfo(False, "Place the Quicksettings under an Accordion").needs_reload_ui(),
             "quicksettings_accordion_starts_closed": OptionInfo(False, "Close the Accordion on startup").info("for the above option").needs_reload_ui(),
             "remove_image_on_hover": OptionInfo(True, "For image inputs in Extras and PNG Info, remove the current image when dragging another image over it").info("allow you to drag-and-drop images onto the input similar to AUTOMATIC1111 behavior").needs_reload_ui(),

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -381,10 +381,12 @@ def create_ui():
                 inputs=txt2img_inputs,
                 outputs=txt2img_outputs,
                 show_progress=False,
+                trigger_mode="multiple",
             )
 
             toprow.prompt.submit(**txt2img_args).then(fn=cleanup)
             toprow.submit.click(**txt2img_args).then(fn=cleanup)
+            toprow.queue.click(**txt2img_args).then(fn=cleanup)
 
             def select_gallery_image(index):
                 index = int(index)
@@ -752,10 +754,12 @@ def create_ui():
                     output_panel.html_log,
                 ],
                 show_progress=False,
+                trigger_mode="multiple",
             )
 
             toprow.prompt.submit(**img2img_args).then(fn=cleanup)
             toprow.submit.click(**img2img_args).then(fn=cleanup)
+            toprow.queue.click(**img2img_args).then(fn=cleanup)
 
             res_switch_btn.click(lambda w, h: (h, w), inputs=[width, height], outputs=[width, height], show_progress=False)
 

--- a/modules/ui_toprow.py
+++ b/modules/ui_toprow.py
@@ -114,6 +114,7 @@ class Toprow:
             self.interrupt = gr.Button("Interrupt", elem_id=f"{self.id_part}_interrupt", elem_classes="generate-box-interrupt", tooltip="End generation immediately or after completing current batch")
             self.skip = gr.Button("Skip", elem_id=f"{self.id_part}_skip", elem_classes="generate-box-skip", tooltip="Stop generation of current batch and continues onto next batch")
             self.interrupting = gr.Button("Interrupting...", elem_id=f"{self.id_part}_interrupting", elem_classes="generate-box-interrupting", tooltip="Interrupting generation...")
+            self.queue = gr.Button("Queue", elem_id=f"{self.id_part}_queue", elem_classes="generate-box-queue", tooltip="Queue a new generation while current one is running")
             self.submit = gr.Button("Generate", elem_id=f"{self.id_part}_generate", variant="primary", tooltip="Right click generate forever menu")
 
             def interrupt_function():

--- a/script.js
+++ b/script.js
@@ -150,10 +150,15 @@ document.addEventListener("keydown", function (e) {
     const generateButton = get_uiCurrentTabContent().querySelector("button[id$=_generate]");
     const interruptButton = get_uiCurrentTabContent().querySelector("button[id$=_interrupt]");
     const skipButton = get_uiCurrentTabContent().querySelector("button[id$=_skip]");
+    const queueButton = get_uiCurrentTabContent().querySelector("button[id$=_queue]");
 
     if (isCtrlKey && isEnter) {
         e.preventDefault();
         if (interruptButton.style.display === "block") {
+            if (queueButton && !opts.ctrl_enter_interrupt) {
+                queueButton.click();
+                return;
+            }
             interruptButton.click();
             if (opts.ctrl_enter_interrupt) return;
             const callback = (mutationList) => {

--- a/style.css
+++ b/style.css
@@ -366,29 +366,67 @@ input[type="checkbox"].input-accordion-checkbox {
 
 .gradio-button.generate-box-skip,
 .gradio-button.generate-box-interrupt,
-.gradio-button.generate-box-interrupting {
+.gradio-button.generate-box-interrupting,
+.gradio-button.generate-box-queue {
     position: absolute;
-    width: 50%;
+    top: 0;
     height: 100%;
+    box-sizing: border-box;
+    min-width: 0;
+    padding-left: 0.25em;
+    padding-right: 0.25em;
+    white-space: nowrap;
     display: none;
+    border: none;
+    border-radius: 0;
     background: #b4c0cc;
 }
 
 .gradio-button.generate-box-skip:hover,
 .gradio-button.generate-box-interrupt:hover,
-.gradio-button.generate-box-interrupting:hover {
+.gradio-button.generate-box-interrupting:hover,
+.gradio-button.generate-box-queue:hover {
     background: #c2cfdb;
 }
 
-.gradio-button.generate-box-interrupt,
-.gradio-button.generate-box-interrupting {
+/* Segmented bar: Queue | Interrupt | Skip */
+.gradio-button.generate-box-queue {
     left: 0;
+    width: calc(100% / 3);
     border-radius: 0.5rem 0 0 0.5rem;
 }
 
+.gradio-button.generate-box-interrupt {
+    left: calc(100% / 3);
+    width: calc(100% / 3);
+    box-shadow:
+        inset 1px 0 0 rgba(0, 0, 0, 0.14),
+        inset -1px 0 0 rgba(0, 0, 0, 0.14);
+}
+
 .gradio-button.generate-box-skip {
+    left: calc(200% / 3);
     right: 0;
+    width: auto;
     border-radius: 0 0.5rem 0.5rem 0;
+}
+
+.gradio-button.generate-box-queue .queue-count {
+    display: inline-block;
+    margin-left: 0.45em;
+    padding: 0 0.45em;
+    border-radius: 999px;
+    background: #0060df;
+    color: #fff;
+    font-size: 0.8em;
+    line-height: 1.5;
+    vertical-align: middle;
+}
+
+.gradio-button.generate-box-interrupting {
+    left: 0;
+    width: 100%;
+    border-radius: 0.5rem;
 }
 
 #img2img_scale_resolution_preview.block {


### PR DESCRIPTION
This PR introduces a task queueing system for txt2img and img2img tabs, allowing users to manage multiple generation tasks simultaneously.

- **UI/Frontend:** Added a "Queue" button with a dynamic count badge and segmented controls for Queue, Interrupt, and Skip actions.
- **UX:** Updated Ctrl+Enter to enqueue tasks by default (with a modified settings option to revert to the old "interrupt" behavior).
- **Backend:** Updated modules/ui.py to support trigger_mode="multiple" for both pipelines.
- **Documentation:** Updated README.md to include the new feature and settings.
<img width="496" height="265" alt="image" src="https://github.com/user-attachments/assets/8e7bbc8e-33fa-4064-bacf-2642b4769ce5" />