### PR TITLE
Add AMD GPU support (ROCm / ZLUDA / DirectML backends)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__
 .DS_Store
 .vscode
 /.uv-cache
+/.zluda
 /cache
 /config.json
 /config_states/

--- a/AMD.md
+++ b/AMD.md
@@ -1,0 +1,200 @@
+# Running on AMD Radeon
+
+This fork runs on AMD GPUs as well as NVIDIA ones. The compute backend is
+detected automatically at launch; nothing has to be configured by hand for the
+common cases.
+
+---
+
+## Quick start (Windows)
+
+Reference configuration this was set up for:
+
+| | |
+|---|---|
+| CPU | AMD Ryzen 5 3600 (6C/12T) |
+| RAM | 64 GB DDR4 |
+| GPU | AMD Radeon RX 6800 (16 GB, `gfx1030`, RDNA 2) |
+| OS | Windows 10 x64 |
+
+1. Install **64-bit Python 3.13** from [python.org](https://www.python.org/downloads/).
+   Tick **"Add python.exe to PATH"** during setup.
+   *(3.12 also works. 3.11 and older do not — the AMD wheels are `cp312`/`cp313` only.)*
+2. Install [Git for Windows](https://git-scm.com/download/win).
+3. Update the **AMD Adrenalin** driver to a current release.
+4. Double-click **`webui-user-amd.bat`**.
+
+The first launch downloads a ROCm build of PyTorch (several GB) and creates the
+`venv` folder. Later launches skip straight to the UI.
+
+There is nothing else to install — the ROCm runtime ships inside the Python
+wheels. You do **not** need the HIP SDK unless you are using the ZLUDA fallback.
+
+---
+
+## The backends
+
+`--gpu-backend` selects one explicitly; the default (`auto`) picks the first
+that applies.
+
+| Backend | Hardware | PyTorch build | Notes |
+|---|---|---|---|
+| `cuda` | NVIDIA | `cu130` | unchanged from upstream |
+| `rocm` | AMD | `+rocm` | **recommended for Radeon**; native, no extra install |
+| `zluda` | AMD, Windows | `cu118` | fallback; needs the AMD HIP SDK |
+| `directml` | any DX12 GPU | `torch-directml` | last resort, see caveats below |
+| `cpu` | — | `+cpu` | very slow; for testing only |
+
+### `rocm` — native ROCm (recommended)
+
+On Windows this uses AMD's ["TheRock"](https://github.com/ROCm/TheRock) wheels,
+which are published per GPU family. Your card's family is detected from the HIP
+runtime that ships with the Adrenalin driver:
+
+| Family | Cards |
+|---|---|
+| `gfx103X-dgpu` | RX 6800 / 6800 XT / 6900 XT / 6950 XT / 6700 / 6600 / 6500 |
+| `gfx110X-all` | RX 7900 / 7800 / 7700 / 7600 |
+| `gfx120X-all` | RX 9070 / 9060 |
+| `gfx1151` | Ryzen AI Max (Strix Halo) |
+
+On Linux the first-party wheels from `download.pytorch.org/whl/rocm7.1` are used
+instead.
+
+If detection gets it wrong, force it:
+
+```bat
+set SD_AMD_ARCH=gfx1030
+```
+
+or point at a different wheel index entirely:
+
+```bat
+set ROCM_INDEX_URL=https://rocm.nightlies.amd.com/v2-staging/gfx103X-dgpu/
+```
+
+### `zluda` — CUDA translation
+
+For Radeon cards AMD does not publish ROCm wheels for. ZLUDA implements the
+CUDA driver API on top of HIP, so the normal `cu118` PyTorch works.
+
+1. Install the [AMD HIP SDK](https://www.amd.com/en/developer/resources/rocm-hub/hip-sdk.html)
+   — **version 6.2 or 6.4**. ZLUDA does not support HIP SDK 7.x.
+2. Launch with `--gpu-backend zluda`.
+
+ZLUDA itself is downloaded automatically into `.zluda` on first use.
+
+Add `--zluda-nightly` to get the nightly build, which enables hipBLASLt and
+MIOpen (faster, but less stable). `--reinstall-zluda` wipes and re-downloads it.
+
+The first generation after each launch is slow — ZLUDA compiles kernels on the
+fly and caches them.
+
+### `directml`
+
+`torch-directml` pins PyTorch to 2.4.1 and Python ≤ 3.12, which is at the very
+bottom of what this codebase supports. It is much slower than ROCm, does not
+support `bf16` or `fp8` weights, and several features are disabled under it.
+Use it only if neither `rocm` nor `zluda` works on your machine.
+
+---
+
+## Tuning for a 16 GB card with plenty of RAM
+
+`webui-user-amd.bat` ships with:
+
+```bat
+set COMMANDLINE_ARGS=--gpu-backend rocm --pin-shared-memory
+```
+
+`--pin-shared-memory` page-locks system RAM (up to 45% of it on Windows) so that
+weights offloaded out of VRAM stream back quickly. With 64 GB installed this is
+close to free, and it is what makes large models usable on 16 GB of VRAM.
+
+Other options worth knowing:
+
+| Flag | Effect |
+|---|---|
+| `--cuda-stream 2` | overlaps weight transfers with compute |
+| `--reserve-vram 1.0` | leaves 1 GB of VRAM for the desktop |
+| `--lowvram` / `--novram` | more aggressive offloading |
+| `--use-pytorch-cross-attention` | SDPA instead of the sliced fallback |
+| `--bf16-unet` | keep bf16 weights (see below) |
+| `--fp16-unet` | force fp16 weights |
+| `--disable-gpu-warning` | silence low-VRAM warnings |
+
+### Precision on RDNA 2
+
+RDNA 2 has no bf16 matrix hardware, so weights are stored and computed in
+**fp16** by default even for models that ship as bf16 (Flux, Krea 2, Qwen-Image,
+Wan). This is the right trade — bf16 on `gfx1030` is emulated and several times
+slower.
+
+If a specific model produces black or corrupted images in fp16, pass
+`--bf16-unet` for it. It will be slow but numerically faithful.
+
+### Attention
+
+`gfx1030` and older have no FlashAttention kernels (AOTriton, which provides
+them on ROCm, starts at `gfx90a`/`gfx1100`). The default is the sliced
+`attention_basic` implementation, which adapts its slice size to free VRAM and
+therefore degrades gracefully at high resolutions.
+
+`--use-pytorch-cross-attention` switches to PyTorch SDPA, pinned to the math
+backend. It is faster at ordinary resolutions but allocates an O(N²) attention
+matrix, so it can run out of memory during hires-fix on large images.
+
+### Large models (Krea 2, Flux, Qwen-Image, Wan)
+
+These do not fit in 16 GB at full precision, and are handled by keeping the
+weights in a compact format and casting them per-layer as they are used:
+
+* **GGUF** checkpoints — fully supported, and the best option on 16 GB.
+* **fp8 (`e4m3fn` / `e5m2`)** checkpoints — the weights stay fp8 in memory and
+  are cast to fp16 for the matmul. RDNA 2 has no fp8 hardware, so `--fast-fp8`
+  has no effect and is ignored.
+* Anything that still does not fit is offloaded to system RAM, which is what
+  `--pin-shared-memory` accelerates.
+
+---
+
+## Flags that do nothing on AMD
+
+These depend on CUDA-only libraries. Passing them prints a message and
+continues, rather than failing the install:
+
+`--xformers` · `--sage` · `--flash` · `--nunchaku` · `--onnxruntime-gpu` ·
+`--cuda-malloc` · `--fast-fp8` (on RDNA 2)
+
+---
+
+## Troubleshooting
+
+**"PyTorch (ROCm) cannot see your Radeon GPU"**
+Update the Adrenalin driver, then delete `venv` and relaunch. If your card is
+older than RDNA 2, try `--gpu-backend zluda`.
+
+**"AMD does not publish Windows ROCm PyTorch wheels for your GPU architecture"**
+Your card has no ROCm wheel family. Use `--gpu-backend zluda`.
+
+**"ZLUDA needs the AMD HIP SDK, which was not found"**
+Install HIP SDK 6.2 or 6.4, or set `HIP_PATH` to an existing install.
+
+**"ZLUDA could not run a trivial matmul on your GPU"**
+Usually a HIP SDK version mismatch (7.x is not supported), or a card whose
+`rocBLAS` libraries are missing from the SDK.
+
+**The warning about a mismatched PyTorch build**
+An extension's `install.py` replaced PyTorch with a CUDA build. Relaunch with
+`--reinstall-torch`.
+
+**Out of memory during hires-fix**
+Drop `--use-pytorch-cross-attention` if you added it, add `--reserve-vram 1.0`,
+or switch to a GGUF/fp8 checkpoint.
+
+---
+
+## Reporting problems
+
+`--dump-sysinfo` writes a report that includes the detected backend, GPU
+architecture and PyTorch build. Attach it to any issue.

--- a/README.md
+++ b/README.md
@@ -247,7 +247,8 @@ The name "Forge" is inspired by "Minecraft Forge". This project aims to become t
 - [X] Update `protobuf`
     - faster `insightface` loading
 - [X] Update to latest PyTorch
-    - `torch==2.13.0+cu130`
+    - `torch==2.13.0+cu130` on NVIDIA
+    - `torch==2.9.1+rocm7.13` on AMD *(see [AMD.md](AMD.md))*
 
 > [!Note]
 > If your GPU does not support the latest PyTorch, manually [install](https://github.com/Haoming02/sd-webui-forge-classic/wiki/Extra-Installations#older-pytorch) older version of PyTorch
@@ -267,7 +268,11 @@ The name "Forge" is inspired by "Minecraft Forge". This project aims to become t
 - `--xformers`: Install the `xformers` package to speed up generation
 
 > [!Warning]
-> `xformers` does **not** support `RTX 50s`
+> `xformers` does **not** support `RTX 50s`, and is **not** available on AMD
+
+- `--gpu-backend`: Pin the compute backend instead of auto-detecting it
+    - one of `cuda`, `rocm`, `zluda`, `directml`, `cpu`
+    - see **[AMD.md](AMD.md)** for the AMD ones
 
 - `--port`: Specify a server port to use
     - defaults to `7860`
@@ -374,14 +379,18 @@ The name "Forge" is inspired by "Minecraft Forge". This project aims to become t
 <br>
 
 3. **(Optional)** Configure [Commandline](#commandline)
-4. Launch the WebUI via `webui-user.bat`
+4. Launch the WebUI via `webui-user.bat` *(**AMD Radeon**: use `webui-user-amd.bat` instead)*
 5. During the first launch, it will automatically install all the requirements
 6. Once the installation is finished, the WebUI will start in a browser automatically
 
 <br>
 
 > [!Tip]
-> - For **AMD**, refer to <a href="https://github.com/CS1o/Stable-Diffusion-Info/wiki/Webui-Installation-Guides#amd-forge-neo-with-rocm"><ins>CS1o</ins> 's Guide</a>
+> - For **AMD**, see **[AMD.md](AMD.md)** — the correct PyTorch build (ROCm, or
+>   ZLUDA as a fallback) is selected and installed automatically; `webui-user-amd.bat`
+>   is a ready-made launcher. Third-party walkthroughs such as
+>   <a href="https://github.com/CS1o/Stable-Diffusion-Info/wiki/Webui-Installation-Guides#amd-forge-neo-with-rocm"><ins>CS1o</ins> 's Guide</a>
+>   remain useful background reading.
 > - For **Linux** and **macOS**, refer to [Wiki](https://github.com/Haoming02/sd-webui-forge-classic/wiki/Unix)
 > - For **Docker** (`Nvidia`), refer to [Docker](docker/)
 

--- a/backend/args.py
+++ b/backend/args.py
@@ -76,6 +76,7 @@ parser.add_argument("--disable-flash", action="store_true", help="disable flash_
 parser.add_argument("--disable-xformers", action="store_true", help="disable xformers")
 
 parser.add_argument("--directml", type=int, nargs="?", metavar="DIRECTML_DEVICE", const=-1, help="Use torch-directml")
+parser.add_argument("--gpu-backend", type=str, default=None, choices=["auto", "cuda", "rocm", "zluda", "directml", "cpu"], help="Which compute backend to run on (default: auto-detect)")
 parser.add_argument("--deterministic", action="store_true", help="Use slower deterministic algorithms when possible")
 
 vram_group = parser.add_mutually_exclusive_group()

--- a/backend/attention.py
+++ b/backend/attention.py
@@ -125,7 +125,9 @@ def _reshape_qkv_to_heads(q, k, v, b, heads, dim_head, enable_gqa=False, expand_
     return q, k, v
 
 
-if memory_management.is_nvidia():
+if memory_management.is_nvidia() or memory_management.AMD_MATH_SDP_ONLY:
+    # The math SDPA fallback materialises the full attention matrix, so the
+    # batch dimension has to stay chunked on AMD cards without real kernels.
     SDP_BATCH_LIMIT = 2**15
 else:
     SDP_BATCH_LIMIT = 2**31

--- a/backend/memory_management.py
+++ b/backend/memory_management.py
@@ -99,6 +99,10 @@ if args.deterministic:
     logger.info("Using deterministic algorithms for PyTorch")
     torch.use_deterministic_algorithms(True, warn_only=True)
 
+# `--gpu-backend directml` is the modern spelling of `--directml`.
+if args.directml is None and (args.gpu_backend == "directml" or os.environ.get("SD_GPU_BACKEND") == "directml"):
+    args.directml = -1
+
 directml_enabled = False
 if args.directml is not None:
     logger.warning("torch-directml barely works; please don't use it, there are better options...")
@@ -129,16 +133,62 @@ if args.cpu:
     cpu_state = CPUState.CPU
 
 
+# ZLUDA implements the CUDA driver API on top of AMD's HIP runtime, so a CUDA
+# build of PyTorch reports `torch.version.cuda` while actually driving a Radeon
+# card. Everything that keys off "is this NVIDIA?" has to know the difference.
+zluda_enabled: bool = os.environ.get("SD_ZLUDA_ACTIVE") == "1"
+
+if not zluda_enabled and torch.version.cuda and not args.cpu:
+    try:
+        zluda_enabled = "[ZLUDA]" in torch.cuda.get_device_name(torch.cuda.current_device())
+    except Exception:
+        zluda_enabled = False
+
+if zluda_enabled:
+    os.environ["SD_ZLUDA_ACTIVE"] = "1"
+    logger.info("ZLUDA detected: running CUDA PyTorch on an AMD GPU")
+
+
 def is_intel_xpu() -> bool:
     return cpu_state is CPUState.GPU and xpu_available
 
 
+def is_zluda() -> bool:
+    return cpu_state is CPUState.GPU and zluda_enabled
+
+
 def is_nvidia() -> bool:
-    return cpu_state is CPUState.GPU and torch.version.cuda
+    return cpu_state is CPUState.GPU and bool(torch.version.cuda) and not zluda_enabled
 
 
 def is_amd() -> bool:
-    return cpu_state is CPUState.GPU and torch.version.hip
+    return cpu_state is CPUState.GPU and (bool(torch.version.hip) or zluda_enabled)
+
+
+def amd_arch(device: torch.device = None) -> str:
+    """
+    LLVM target of the active AMD GPU, e.g. ``"gfx1030"`` for an RX 6800.
+
+    ROCm exposes it through the device properties; ZLUDA does not, so fall back
+    to querying the HIP runtime directly.
+    """
+
+    if not is_amd():
+        return ""
+
+    try:
+        arch = getattr(torch.cuda.get_device_properties(device), "gcnArchName", "")
+        if arch:
+            return arch.split(":")[0]
+    except Exception:
+        pass
+
+    try:
+        from modules_forge.gpu_backend import amd_arch as probe_amd_arch
+
+        return probe_amd_arch() or ""
+    except Exception:
+        return ""
 
 
 def get_torch_device() -> torch.device:
@@ -249,7 +299,7 @@ def amd_min_version(device: torch.device = None, min_rdna_version: int = 0) -> b
     if is_device_cpu(device):
         return False
 
-    arch = torch.cuda.get_device_properties(device).gcnArchName
+    arch = amd_arch(device)
     if arch.startswith("gfx") and len(arch) == 7:
         try:
             cmp_rdna_version = int(arch[4]) + 2
@@ -281,12 +331,18 @@ elif is_intel_xpu():
 
 SUPPORT_FP8_OPS: bool = None
 
-if is_amd():
-    AMD_RDNA2_AND_OLDER_ARCH = ("gfx1030", "gfx1031", "gfx1010", "gfx1011", "gfx1012", "gfx906", "gfx900", "gfx803")
+AMD_RDNA2_AND_OLDER_ARCH = ("gfx1030", "gfx1031", "gfx1010", "gfx1011", "gfx1012", "gfx906", "gfx900", "gfx803")
 
+#: True when the GPU has no hardware FlashAttention / memory-efficient SDPA
+#: kernels, and PyTorch's math backend has to be used instead.
+AMD_MATH_SDP_ONLY: bool = False
+
+if is_amd():
     try:
-        arch = torch.cuda.get_device_properties(get_torch_device()).gcnArchName
-        if not (any((a in arch) for a in AMD_RDNA2_AND_OLDER_ARCH)):
+        arch = amd_arch(get_torch_device())
+        is_rdna2_or_older = any((a in arch) for a in AMD_RDNA2_AND_OLDER_ARCH)
+
+        if not is_rdna2_or_older:
             if os.getenv("ENABLE_MIOPEN") != "1":
                 torch.backends.cudnn.enabled = False
 
@@ -295,24 +351,44 @@ if is_amd():
         except Exception:
             rocm_version = (6, -1)
 
-        logger.info("AMD Arch: {}".format(arch))
-        logger.info("ROCm Version: {}".format(rocm_version))
-        if importlib.util.find_spec("triton") is not None:
-            if torch_version_numeric >= (2, 7):
-                if any((a in arch) for a in ["gfx90a", "gfx942", "gfx1100", "gfx1101", "gfx1151"]):
-                    ENABLE_PYTORCH_ATTENTION = True
-            if rocm_version >= (7, 0):
-                if any((a in arch) for a in ["gfx1201"]):
-                    ENABLE_PYTORCH_ATTENTION = True
-        if torch_version_numeric >= (2, 7) and rocm_version >= (6, 4):
-            if any((a in arch) for a in ["gfx1200", "gfx1201", "gfx950"]):
-                SUPPORT_FP8_OPS = True
+        logger.info("AMD Arch: {}".format(arch or "unknown"))
+        if not is_zluda():
+            logger.info("ROCm Version: {}".format(rocm_version))
+
+        if is_zluda() or is_rdna2_or_older:
+            # AOTriton (the ROCm FlashAttention backend) does not cover RDNA 2
+            # and older, and ZLUDA implements neither FlashAttention nor the
+            # memory-efficient kernels. SDPA is left off by default -- the
+            # sliced fallback in `attention_basic` adapts to free VRAM, which
+            # matters on 16 GB cards -- but `--use-pytorch-cross-attention`
+            # still has to end up on a backend that actually exists.
+            AMD_MATH_SDP_ONLY = True
+        else:
+            if importlib.util.find_spec("triton") is not None:
+                if torch_version_numeric >= (2, 7):
+                    if any((a in arch) for a in ["gfx90a", "gfx942", "gfx1100", "gfx1101", "gfx1151"]):
+                        ENABLE_PYTORCH_ATTENTION = True
+                if rocm_version >= (7, 0):
+                    if any((a in arch) for a in ["gfx1201"]):
+                        ENABLE_PYTORCH_ATTENTION = True
+            if torch_version_numeric >= (2, 7) and rocm_version >= (6, 4):
+                if any((a in arch) for a in ["gfx1200", "gfx1201", "gfx950"]):
+                    SUPPORT_FP8_OPS = True
 
     except Exception:
         pass
 
 
-if ENABLE_PYTORCH_ATTENTION:
+if AMD_MATH_SDP_ONLY:
+    # Leaving these enabled makes `sdpa_kernel(...)` raise instead of falling
+    # back, because the kernels are advertised but not implemented.
+    torch.backends.cuda.enable_math_sdp(True)
+    for _toggle in ("enable_flash_sdp", "enable_mem_efficient_sdp", "enable_cudnn_sdp"):
+        try:
+            getattr(torch.backends.cuda, _toggle)(False)
+        except Exception:
+            pass
+elif ENABLE_PYTORCH_ATTENTION:
     torch.backends.cuda.enable_math_sdp(True)
     torch.backends.cuda.enable_flash_sdp(True)
     torch.backends.cuda.enable_mem_efficient_sdp(True)
@@ -1023,6 +1099,9 @@ def xformers_enabled() -> bool:
         return False
     if directml_enabled:
         return False
+    if is_zluda():
+        # xformers' kernels are compiled CUDA; ZLUDA cannot load them.
+        return False
     return XFORMERS_IS_AVAILABLE
 
 
@@ -1073,6 +1152,8 @@ def pytorch_attention_enabled_vae() -> bool:
 
 def pytorch_attention_flash_attention() -> bool:
     if ENABLE_PYTORCH_ATTENTION:
+        if AMD_MATH_SDP_ONLY:
+            return False
         if is_nvidia():
             return True
         if is_intel_xpu():
@@ -1177,7 +1258,9 @@ def should_use_fp16(device: torch.device = None, model_params: int = 0, prioriti
     if is_intel_xpu():
         return torch.xpu.get_device_properties(device).has_fp16
 
-    if torch.version.hip:
+    if is_amd():
+        # Every GPU ROCm/ZLUDA runs on has usable fp16; the compute-capability
+        # checks below are meaningless for them (and ZLUDA reports a made-up one).
         return True
 
     props = torch.cuda.get_device_properties(device)
@@ -1233,7 +1316,11 @@ def should_use_bf16(device: torch.device = None, model_params: int = 0, prioriti
         return torch.xpu.is_bf16_supported()
 
     if is_amd():
-        arch = torch.cuda.get_device_properties(device).gcnArchName
+        arch = amd_arch(device)
+        if not arch:
+            # Unknown architecture (typical under ZLUDA): bf16 would be emulated
+            # at best, so stay on fp16.
+            return False
         if any((a in arch) for a in AMD_RDNA2_AND_OLDER_ARCH):
             if manual_cast:
                 return True
@@ -1349,7 +1436,9 @@ def soft_empty_cache(force=False):
     elif torch.cuda.is_available():
         torch.cuda.synchronize()
         torch.cuda.empty_cache()
-        torch.cuda.ipc_collect()
+        if not is_zluda():
+            # CUDA IPC is not implemented by ZLUDA, and is a no-op on ROCm.
+            torch.cuda.ipc_collect()
 
     global signal_empty_cache
     signal_empty_cache = False
@@ -1454,7 +1543,10 @@ TOTAL_PINNED_MEMORY = 0
 MAX_PINNED_MEMORY = -1
 
 if args.pin_shared_memory:
-    if is_nvidia() or is_amd():
+    if is_zluda():
+        # cudaHostRegister is not implemented by ZLUDA.
+        logger.warning("Ignoring --pin-shared-memory: not supported under ZLUDA")
+    elif is_nvidia() or is_amd():
         if WINDOWS:
             MAX_PINNED_MEMORY = get_total_memory(torch.device("cpu")) * 0.45  # Windows limit is apparently 50%
         else:
@@ -1468,7 +1560,7 @@ def discard_cuda_async_error():
         b = torch.tensor([1], dtype=torch.uint8, device=get_torch_device())
         _ = a + b
         torch.cuda.synchronize()
-    except torch.AcceleratorError:
+    except ACCELERATOR_ERROR:
         pass
 
 

--- a/backend/operations.py
+++ b/backend/operations.py
@@ -42,12 +42,18 @@ try:
         from torch.nn.attention import SDPBackend, sdpa_kernel
 
         if "set_priority" in inspect.signature(sdpa_kernel).parameters:
-            SDPA_BACKEND_PRIORITY = [
-                SDPBackend.FLASH_ATTENTION,
-                SDPBackend.CUDNN_ATTENTION,
-                SDPBackend.EFFICIENT_ATTENTION,
-                SDPBackend.MATH,
-            ]
+            if memory_management.AMD_MATH_SDP_ONLY:
+                # RDNA 2 (and ZLUDA) have no FlashAttention / cuDNN / efficient
+                # SDPA kernels; listing them makes sdpa_kernel raise instead of
+                # quietly picking the math implementation.
+                SDPA_BACKEND_PRIORITY = [SDPBackend.MATH]
+            else:
+                SDPA_BACKEND_PRIORITY = [
+                    SDPBackend.FLASH_ATTENTION,
+                    SDPBackend.CUDNN_ATTENTION,
+                    SDPBackend.EFFICIENT_ATTENTION,
+                    SDPBackend.MATH,
+                ]
 
             def scaled_dot_product_attention(q, k, v, *args, **kwargs):
                 attn_mask = args[0] if len(args) > 0 else kwargs.get("attn_mask")

--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -20,6 +20,12 @@ parser.add_argument("--skip-prepare-environment", action="store_true", help="lau
 parser.add_argument("--skip-install", action="store_true", help="launch.py argument: skip installation of packages")
 parser.add_argument("--dump-sysinfo", action="store_true", help="launch.py argument: dump limited sysinfo file (without information about extensions, options) to disk and quit")
 
+parser = _parser.add_argument_group(description="compute backend")
+# NOTE: --gpu-backend itself lives in backend/args.py, whose parser is a parent
+# of this one, because the runtime (memory_management) needs it too.
+parser.add_argument("--zluda-nightly", action="store_true", help="launch.py argument: use the nightly ZLUDA build (adds hipBLASLt & MIOpen support)")
+parser.add_argument("--reinstall-zluda", action="store_true", help="launch.py argument: delete and re-download ZLUDA")
+
 parser = _parser.add_argument_group(description="connections")
 parser.add_argument("--share", action="store_true", help="use share=True for gradio and make the UI accessible through their site")
 parser.add_argument("--ngrok", type=str, help="ngrok authtoken, alternative to gradio --share", default=None)

--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -17,7 +17,7 @@ from typing import Any, Final, NamedTuple
 from modules import cmd_args, errors
 from modules.paths_internal import extensions_builtin_dir, extensions_dir, script_path
 from modules.timer import startup_timer
-from modules_forge import forge_version
+from modules_forge import forge_version, gpu_backend
 from modules_forge.config import always_disabled_extensions
 
 args, _ = cmd_args.parser.parse_known_args()
@@ -32,19 +32,26 @@ default_command_live = os.environ.get("WEBUI_LAUNCH_LIVE_OUTPUT") == "1"
 os.environ.setdefault("GRADIO_ANALYTICS_ENABLED", "False")
 
 
+#: Python versions every supported backend publishes wheels for.
+SUPPORTED_PYTHON_MINORS: Final[tuple[int, ...]] = (12, 13)
+
+
 def check_python_version():
     major = sys.version_info.major
     minor = sys.version_info.minor
     micro = sys.version_info.micro
 
-    if not (major == 3 and minor == 13):
+    if not (major == 3 and minor in SUPPORTED_PYTHON_MINORS):
         import modules.errors
 
+        supported = " or ".join(f"3.{m}" for m in SUPPORTED_PYTHON_MINORS)
         modules.errors.print_error_explanation(f"""
             This program is tested with 3.13.12 Python, but you have {major}.{minor}.{micro}.
             If you encounter any error regarding unsuccessful package/library installation,
-            please downgrade (or upgrade) to the latest version of 3.13 Python,
+            please downgrade (or upgrade) to the latest version of {supported} Python,
             and delete the current Python "venv" folder in WebUI's directory.
+
+            AMD (ROCm) wheels are only published for {supported}.
 
             Use --skip-python-version-check to suppress this warning
             """)
@@ -94,6 +101,11 @@ def _torch_version() -> tuple[str, str]:
     m = re.search(r"(\d+\.\d+\.\d+)(?:[^+]+)?\+(.+)", ver)
 
     if m is None:
+        # Builds without a local version label (e.g. plain CPU wheels from PyPI)
+        m = re.fullmatch(r"(\d+\.\d+\.\d+).*", ver)
+        if m is not None:
+            return m.group(1), "cpu"
+
         print("\n\nFailed to parse PyTorch version...")
         ver = os.environ.get("PYTORCH_VERSION", "2.10.0+cu130")
         print("Assuming: ", ver)
@@ -283,9 +295,138 @@ def requirements_met(requirements_file):
     return True
 
 
+#: Pinned PyTorch builds per backend.
+#:
+#: ROCm: AMD publishes Windows wheels through "TheRock" nightly channel. They
+#: are date stamped and `torch` pins `rocm[libraries]` to the exact same stamp,
+#: so the whole trio has to move together -- hence the pin.
+ROCM_LINUX_CHANNEL: Final[str] = os.environ.get("ROCM_CHANNEL", "rocm7.1")
+TORCH_ROCM_VERSION: Final[str] = "2.9.1+rocm7.13.0a20260421"
+TORCHVISION_ROCM_VERSION: Final[str] = "0.27.0a0+rocm7.13.0a20260421"
+
+#: ZLUDA translates the CUDA driver API, and only implements CUDA 11.x, so the
+#: cu118 build of PyTorch is the one to use.
+TORCH_ZLUDA_VERSION: Final[str] = "2.7.1+cu118"
+TORCHVISION_ZLUDA_VERSION: Final[str] = "0.22.1+cu118"
+
+
+def resolve_gpu_backend() -> str:
+    """Backend to install for; see `modules_forge/gpu_backend.py`."""
+
+    backend = gpu_backend.select_backend(getattr(args, "gpu_backend", None))
+    os.environ["SD_GPU_BACKEND"] = backend
+    return backend
+
+
+def torch_install_command(backend: str) -> str:
+    """`pip install ...` arguments that put the right PyTorch build in place."""
+
+    explicit = os.environ.get("TORCH_COMMAND")
+    if explicit:
+        return explicit
+
+    if backend == gpu_backend.Backend.ROCM:
+        if os.name != "nt":
+            # Linux has first-party ROCm wheels on the regular PyTorch index.
+            index = os.environ.get("TORCH_INDEX_URL", f"https://download.pytorch.org/whl/{ROCM_LINUX_CHANNEL}")
+            return f"pip install torch torchvision --index-url {index}"
+
+        index = gpu_backend.rocm_index_url()
+        if index is None:
+            arch = gpu_backend.amd_arch() or "unknown"
+            raise RuntimeError(f"""AMD does not publish Windows ROCm PyTorch wheels for your GPU architecture ({arch}).
+Run with --gpu-backend zluda instead (requires the AMD HIP SDK 6.2/6.4), or
+set ROCM_INDEX_URL to a wheel index that covers your card.""")
+        torch_pin = os.environ.get("TORCH_VERSION", TORCH_ROCM_VERSION)
+        vision_pin = os.environ.get("TORCHVISION_VERSION", TORCHVISION_ROCM_VERSION)
+        # Every transitive dependency (including the rocm-sdk runtime packages)
+        # is served by the same index, so it is used as the *primary* one.
+        return f"pip install --pre torch=={torch_pin} torchvision=={vision_pin} --index-url {index}"
+
+    if backend == gpu_backend.Backend.ZLUDA:
+        index = os.environ.get("TORCH_INDEX_URL", "https://download.pytorch.org/whl/cu118")
+        torch_pin = os.environ.get("TORCH_VERSION", TORCH_ZLUDA_VERSION)
+        vision_pin = os.environ.get("TORCHVISION_VERSION", TORCHVISION_ZLUDA_VERSION)
+        return f"pip install torch=={torch_pin} torchvision=={vision_pin} --extra-index-url {index}"
+
+    if backend == gpu_backend.Backend.DIRECTML:
+        return "pip install torch-directml"
+
+    if backend == gpu_backend.Backend.CPU:
+        index = os.environ.get("TORCH_INDEX_URL", "https://download.pytorch.org/whl/cpu")
+        return f"pip install torch torchvision --index-url {index}"
+
+    index = os.environ.get("TORCH_INDEX_URL", "https://download.pytorch.org/whl/cu130")
+    return f"pip install torch==2.13.0+cu130 torchvision==0.28.0+cu130 --extra-index-url {index}"
+
+
+def prepare_zluda():
+    """Fetch ZLUDA and verify the HIP SDK is in place (Windows + AMD only)."""
+
+    from modules_forge import zluda_installer
+
+    if os.name != "nt":
+        raise RuntimeError("ZLUDA is only supported on Windows; use --gpu-backend rocm on Linux.")
+
+    hip_sdk = gpu_backend.hip_sdk_path()
+    if hip_sdk is None:
+        raise RuntimeError("""ZLUDA needs the AMD HIP SDK, which was not found.
+Install HIP SDK 6.2 (or 6.4) from https://www.amd.com/en/developer/resources/rocm-hub/hip-sdk.html and re-launch.
+HIP SDK 7.x is not supported by ZLUDA.""")
+
+    version = gpu_backend.hip_sdk_version()
+    if version is not None and version[0] != 6:
+        print(f"Warning: ZLUDA is built against HIP SDK 6.x, but {version[0]}.{version[1]} was found. Expect failures.")
+
+    print(f"HIP SDK: {hip_sdk}")
+
+    if args.reinstall_zluda:
+        zluda_installer.uninstall()
+
+    try:
+        zluda_installer.install(use_nightly=args.zluda_nightly)
+    except Exception as e:
+        raise RuntimeError(f"Couldn't install ZLUDA: {e}") from e
+
+    startup_timer.record("install zluda")
+
+
+def verify_torch_build(backend: str):
+    """
+    Warn when installing the requirements pulled a PyTorch build that does not
+    match the selected backend -- this silently breaks GPU acceleration and is
+    otherwise very hard to diagnose.
+    """
+
+    expected = {
+        gpu_backend.Backend.ROCM: "rocm",
+        gpu_backend.Backend.ZLUDA: "cu",
+        gpu_backend.Backend.CUDA: "cu",
+    }.get(backend)
+
+    if expected is None:
+        return
+
+    try:
+        installed = importlib.metadata.version("torch")
+    except Exception:
+        return
+
+    local = installed.partition("+")[2]
+    if local.startswith(expected):
+        return
+
+    print(f"""
+Warning: the '{backend}' backend expects a '{expected}*' build of PyTorch, but '{installed}' is installed.
+Something (usually an extension's install.py) replaced it. Re-run with --reinstall-torch to fix.
+""")
+
+
 def prepare_environment():
+    backend = resolve_gpu_backend()
+
     torch_index_url = os.environ.get("TORCH_INDEX_URL", "https://download.pytorch.org/whl/cu130")
-    torch_command = os.environ.get("TORCH_COMMAND", f"pip install torch==2.13.0+cu130 torchvision==0.28.0+cu130 --extra-index-url {torch_index_url}")
+    torch_command = torch_install_command(backend)
     xformers_package = os.environ.get("XFORMERS_PACKAGE", f"xformers==0.0.35 --extra-index-url {torch_index_url}")
 
     packaging_package = os.environ.get("PACKAGING_PACKAGE", "packaging==26.2")
@@ -309,14 +450,21 @@ def prepare_environment():
     print(f"Python {sys.version}")
     print(f"Version: {tag}")
 
-    if args.reinstall_torch or not is_installed("torch") or not is_installed("torchvision"):
+    print(f"Compute backend: {backend}")
+    if backend in gpu_backend.Backend.AMD:
+        print(f"AMD GPU: {', '.join(gpu_backend.amd_gpu_names()) or 'unknown'} ({gpu_backend.amd_arch() or 'unknown arch'})")
+
+    if args.reinstall_torch or not is_installed("torch") or (backend != gpu_backend.Backend.DIRECTML and not is_installed("torchvision")):
         # TODO: Yeet Nunchaku...
-        if args.nunchaku:
+        if args.nunchaku and backend == gpu_backend.Backend.CUDA:
             torch_command = os.environ.get("TORCH_COMMAND", f"pip install torch==2.11.0+cu130 torchvision==0.26.0+cu130 --extra-index-url {torch_index_url}")
             print("(using an older version of PyTorch due to Nunchaku dependency...)")
 
         run(f'"{python}" -m {torch_command}', "Installing PyTorch", "Couldn't install PyTorch", live=True)
         startup_timer.record("install torch")
+
+    if backend == gpu_backend.Backend.ZLUDA:
+        prepare_zluda()
 
     if not args.skip_torch_cuda_test:
         TORCH_CHECK: str = """
@@ -327,12 +475,27 @@ mps = hasattr(torch, "mps") and torch.mps.is_available()
 assert cuda or xpu or mps
         """
 
-        success, err = check_run_python(TORCH_CHECK, return_error=True)
-        if not success:
-            if "older driver" in str(err).lower():
-                raise SystemError("Please update your GPU driver or manually install older version of PyTorch")
-            raise RuntimeError("PyTorch is not able to access any compute device (GPU)")
-        startup_timer.record("torch GPU test")
+        if backend == gpu_backend.Backend.DIRECTML:
+            TORCH_CHECK = "import torch_directml\nassert torch_directml.device_count() > 0"
+
+        if backend == gpu_backend.Backend.CPU:
+            startup_timer.record("torch GPU test")
+        else:
+            success, err = check_run_python(TORCH_CHECK, return_error=True)
+            if not success:
+                message = str(err).lower()
+                if "older driver" in message:
+                    raise SystemError("Please update your GPU driver or manually install older version of PyTorch")
+                if backend == gpu_backend.Backend.ROCM:
+                    detail = err.decode("utf-8", "ignore") if isinstance(err, bytes) else err
+                    family = gpu_backend.therock_family(gpu_backend.amd_arch())
+                    raise RuntimeError(f"""PyTorch (ROCm) cannot see your Radeon GPU.
+  * make sure the AMD Adrenalin driver is up to date
+  * confirm your GPU belongs to the {family!r} wheel family
+  * or fall back to ZLUDA with --gpu-backend zluda
+{detail}""")
+                raise RuntimeError("PyTorch is not able to access any compute device (GPU)")
+            startup_timer.record("torch GPU test")
 
     if not is_installed("packaging"):
         run_pip(f"install {packaging_package}", "packaging")
@@ -359,6 +522,12 @@ assert cuda or xpu or mps
         flash_package = os.environ.get("FLASH_PACKAGE", f"https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.47/flash_attn-{ver_FLASH}+{ver_CUDA}torch{v_TORCH}-{ver_PY}-{ver_PY}-linux_x86_64.whl")
         triton_package = os.environ.get("TRITION_PACKAGE", f"triton=={ver_TRITON}")
         nunchaku_package = os.environ.get("NUNCHAKU_PACKAGE", f"https://github.com/nunchaku-ai/nunchaku/releases/download/v{ver_NUNCHAKU}/nunchaku-{ver_NUNCHAKU}+{v_CUDA}torch{v_TORCH}-{ver_PY}-{ver_PY}-linux_x86_64.whl")
+
+    cuda_only_requested = [name for name, enabled in (("--xformers", args.xformers), ("--sage", args.sage), ("--flash", args.flash), ("--nunchaku", args.nunchaku), ("--onnxruntime-gpu", args.onnxruntime_gpu)) if enabled]
+
+    if backend != gpu_backend.Backend.CUDA and cuda_only_requested:
+        print(f"Ignoring {', '.join(cuda_only_requested)}: these packages are CUDA-only and cannot run on the '{backend}' backend.")
+        args.xformers = args.sage = args.flash = args.nunchaku = args.onnxruntime_gpu = False
 
     if args.xformers and (not is_installed("xformers") or args.reinstall_xformers):
         run_pip(f"install -U -I --no-deps {xformers_package}", "xformers")
@@ -400,6 +569,10 @@ assert cuda or xpu or mps
         run_pip("install ngrok", "ngrok")
         startup_timer.record("install ngrok")
 
+    if backend == gpu_backend.Backend.DIRECTML and not is_installed("torch_directml"):
+        run_pip("install torch-directml", "torch-directml")
+        startup_timer.record("install torch-directml")
+
     if not is_installed("gradio"):
         run_pip(f"install {gradio_package}", "gradio")
 
@@ -428,6 +601,8 @@ assert cuda or xpu or mps
     if not requirements_met(requirements_file):
         run_pip(f'install -r "{requirements_file}"', "requirements")
         startup_timer.record("enforce requirements")
+
+    verify_torch_build(backend)
 
     if "--exit" in sys.argv:
         print("Exiting because of --exit argument")

--- a/modules/sysinfo.py
+++ b/modules/sysinfo.py
@@ -92,6 +92,33 @@ def get_packages():
             return {'error pip': pip_error, 'error importlib': str(e2)}
 
 
+def get_gpu_info():
+    """Detected compute backend and GPU, so AMD reports are actionable."""
+
+    from modules_forge import gpu_backend
+
+    info = {
+        "adapters": list(gpu_backend.list_gpu_names()),
+        "backend": os.environ.get("SD_GPU_BACKEND") or gpu_backend.installed_backend(),
+    }
+
+    if gpu_backend.has_amd_gpu():
+        info["amd arch"] = gpu_backend.amd_arch()
+        info["rocm wheel index"] = gpu_backend.rocm_index_url()
+        info["hip sdk"] = gpu_backend.hip_sdk_path()
+
+    try:
+        import torch
+
+        info["torch"] = torch.__version__
+        info["torch cuda"] = torch.version.cuda
+        info["torch hip"] = torch.version.hip
+    except Exception:
+        pass
+
+    return info
+
+
 def get_dict():
     config = get_config()
     res = {
@@ -104,6 +131,7 @@ def get_dict():
         "Extensions dir": paths_internal.extensions_dir,
         "Checksum": checksum_token,
         "Commandline": get_argv(),
+        "GPU": get_gpu_info(),
         "Torch env info": get_torch_sysinfo(),
         "Exceptions": errors.get_exceptions(),
         "CPU": get_cpu_info(),

--- a/modules_forge/cuda_malloc.py
+++ b/modules_forge/cuda_malloc.py
@@ -1,13 +1,14 @@
 # reference: https://github.com/Comfy-Org/ComfyUI/blob/master/cuda_malloc.py
 
 import importlib.util
+import os
 import os.path
 import subprocess
 
 
 def get_gpu_names() -> set[str]:
     gpu_names = set()
-    out = subprocess.check_output(["nvidia-smi", "-L"])
+    out = subprocess.check_output(["nvidia-smi", "-L"], stderr=subprocess.DEVNULL)
     for l in out.split(b"\n"):
         if len(l) > 0:
             gpu_names.add(l.decode("utf-8").split(" (UUID")[0])
@@ -43,6 +44,16 @@ except Exception:
 
 
 def try_cuda_malloc():
+    if "rocm" in get_torch_version().lower():
+        # hipMallocAsync exists but the caching allocator is the tested path on
+        # ROCm; PYTORCH_CUDA_ALLOC_CONF=backend:cudaMallocAsync regresses it.
+        print("Ignoring --cuda-malloc: not applicable to ROCm builds of PyTorch")
+        return
+
+    if os.environ.get("SD_ZLUDA_ACTIVE") == "1":
+        print("Ignoring --cuda-malloc: cudaMallocAsync is not implemented by ZLUDA")
+        return
+
     if not cuda_malloc_supported():
         return
 

--- a/modules_forge/gpu_backend.py
+++ b/modules_forge/gpu_backend.py
@@ -1,0 +1,460 @@
+"""
+Compute backend detection & selection.
+
+This module is imported by `modules/launch_utils.py` *before* PyTorch is
+installed, therefore it must only use the standard library.
+
+Supported backends
+------------------
+``cuda``     NVIDIA GPUs (the historical default of this repository)
+``rocm``     AMD GPUs using native ROCm PyTorch wheels (Linux, and Windows via
+             AMD's "TheRock" nightly wheels)
+``zluda``    AMD GPUs on Windows using CUDA PyTorch wheels translated by ZLUDA
+             (requires the AMD HIP SDK to be installed)
+``directml`` Any DirectX 12 GPU through ``torch-directml`` (very limited)
+``cpu``      No GPU acceleration
+"""
+
+import functools
+import json
+import os
+import re
+import subprocess
+import sys
+
+IS_WINDOWS = os.name == "nt"
+
+
+class Backend:
+    CUDA = "cuda"
+    ROCM = "rocm"
+    ZLUDA = "zluda"
+    DIRECTML = "directml"
+    CPU = "cpu"
+
+    ALL = ("cuda", "rocm", "zluda", "directml", "cpu")
+    AMD = ("rocm", "zluda")
+
+
+# region GPU discovery
+
+
+#: Marketing name (lower-case substring) -> LLVM ``gfx`` target.
+#: Only used as a fallback when the HIP runtime cannot be queried.
+AMD_ARCH_BY_NAME: tuple[tuple[str, str], ...] = (
+    # RDNA 4
+    ("rx 9070", "gfx1201"),
+    ("rx 9060", "gfx1200"),
+    # RDNA 3
+    ("rx 7900", "gfx1100"),
+    ("rx 7800", "gfx1101"),
+    ("rx 7700", "gfx1101"),
+    ("rx 7650", "gfx1102"),
+    ("rx 7600", "gfx1102"),
+    ("radeon 890m", "gfx1151"),
+    ("radeon 880m", "gfx1150"),
+    ("radeon 780m", "gfx1103"),
+    ("radeon 760m", "gfx1103"),
+    # RDNA 2
+    ("rx 6950", "gfx1030"),
+    ("rx 6900", "gfx1030"),
+    ("rx 6800", "gfx1030"),
+    ("rx 6750", "gfx1031"),
+    ("rx 6700", "gfx1031"),
+    ("rx 6650", "gfx1032"),
+    ("rx 6600", "gfx1032"),
+    ("rx 6500", "gfx1034"),
+    ("rx 6400", "gfx1034"),
+    ("radeon 680m", "gfx1035"),
+    ("radeon 660m", "gfx1035"),
+    ("pro w6800", "gfx1030"),
+    ("pro w6600", "gfx1032"),
+    # RDNA 1
+    ("rx 5700", "gfx1010"),
+    ("rx 5600", "gfx1012"),
+    ("rx 5500", "gfx1012"),
+    # GCN
+    ("radeon vii", "gfx906"),
+    ("vega 64", "gfx900"),
+    ("vega 56", "gfx900"),
+    ("rx 590", "gfx803"),
+    ("rx 580", "gfx803"),
+    ("rx 570", "gfx803"),
+)
+
+
+def _run(command: list[str] | str, timeout: int = 30) -> str:
+    try:
+        proc = subprocess.run(
+            command,
+            shell=isinstance(command, str),
+            check=False,
+            timeout=timeout,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception:
+        return ""
+    return proc.stdout.decode("utf-8", errors="ignore")
+
+
+@functools.cache
+def list_gpu_names() -> tuple[str, ...]:
+    """Names of every display adapter present in the system."""
+
+    names: list[str] = []
+
+    if IS_WINDOWS:
+        out = _run(
+            [
+                "powershell",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "Get-CimInstance Win32_VideoController | Select-Object -ExpandProperty Name",
+            ]
+        )
+        names = [line.strip() for line in out.splitlines() if line.strip()]
+
+        if not names:  # very old Windows 10 builds without CIM cmdlets
+            out = _run("wmic path win32_VideoController get name")
+            names = [line.strip() for line in out.splitlines()[1:] if line.strip()]
+    else:
+        out = _run("lspci -mm")
+        for line in out.splitlines():
+            if re.search(r'"(VGA compatible controller|Display controller|3D controller)"', line):
+                fields = re.findall(r'"([^"]*)"', line)
+                if len(fields) >= 4:
+                    names.append(f"{fields[2]} {fields[3]}".strip())
+
+    return tuple(names)
+
+
+@functools.cache
+def has_nvidia_gpu() -> bool:
+    if _run(["nvidia-smi", "-L"]).strip():
+        return True
+    return any("nvidia" in name.lower() for name in list_gpu_names())
+
+
+@functools.cache
+def has_amd_gpu() -> bool:
+    return bool(amd_gpu_names())
+
+
+@functools.cache
+def amd_gpu_names() -> tuple[str, ...]:
+    found = []
+    for name in list_gpu_names():
+        lowered = name.lower()
+        if "amd" in lowered or "radeon" in lowered or "advanced micro devices" in lowered:
+            found.append(name)
+    return tuple(found)
+
+
+# The HIP runtime (``amdhip64*.dll``) ships with the AMD Adrenalin driver, so it
+# is normally available even when neither the HIP SDK nor ROCm is installed.
+# Querying it is far more reliable than matching marketing names.
+_HIP_ARCH_PROBE = r"""
+import ctypes, ctypes.util, os, sys
+
+def load():
+    if os.name == "nt":
+        root = os.path.join(os.environ.get("windir", r"C:\Windows"), "System32")
+        for dll in ("amdhip64_7.dll", "amdhip64_6.dll", "amdhip64.dll"):
+            path = os.path.join(root, dll)
+            if os.path.isfile(path):
+                try:
+                    return ctypes.CDLL(path)
+                except OSError:
+                    continue
+        return None
+    for so in ("libamdhip64.so", "libamdhip64.so.6", "libamdhip64.so.5"):
+        try:
+            return ctypes.CDLL(so)
+        except OSError:
+            continue
+    return None
+
+hip = load()
+if hip is None:
+    raise SystemExit(1)
+
+# hipDeviceProp_t is large and version dependent; over-allocate and scan it for
+# the NUL terminated "gfx...." string that describes the compute architecture.
+BUFFER = ctypes.c_byte * 4096
+
+hip.hipInit(0)
+count = ctypes.c_int()
+if hip.hipGetDeviceCount(ctypes.byref(count)) != 0:
+    raise SystemExit(1)
+
+for index in range(count.value):
+    prop = BUFFER()
+    getter = getattr(hip, "hipGetDevicePropertiesR0600", None) or hip.hipGetDeviceProperties
+    if getter(ctypes.byref(prop), index) != 0:
+        continue
+    raw = bytes(prop)
+    match = None
+    start = 0
+    while True:
+        start = raw.find(b"gfx", start)
+        if start == -1:
+            break
+        end = start
+        while end < len(raw) and raw[end] not in (0, 0x3A):  # NUL or ':'
+            end += 1
+        candidate = raw[start:end].decode("ascii", "ignore")
+        if len(candidate) >= 6 and candidate[3:].strip("0123456789abcdef") == "":
+            match = candidate
+            break
+        start += 3
+    print(f"{index}\t{match or ''}")
+"""
+
+
+@functools.cache
+def hip_agents() -> tuple[str, ...]:
+    """``gfx`` target of every HIP visible device, in device order."""
+
+    out = _run([sys.executable, "-c", _HIP_ARCH_PROBE], timeout=60)
+    agents = []
+    for line in out.splitlines():
+        _, _, arch = line.partition("\t")
+        arch = arch.strip()
+        if arch:
+            agents.append(arch)
+    return tuple(agents)
+
+
+def _arch_from_name(name: str) -> str | None:
+    lowered = name.lower()
+    for needle, arch in AMD_ARCH_BY_NAME:
+        if needle in lowered:
+            return arch
+    return None
+
+
+@functools.cache
+def amd_arch() -> str | None:
+    """``gfx`` target of the AMD GPU this install should be built for."""
+
+    override = os.environ.get("SD_AMD_ARCH") or os.environ.get("GFX_VERSION")
+    if override:
+        return override.split(":")[0].strip()
+
+    agents = hip_agents()
+    if agents:
+        return agents[0]
+
+    for name in amd_gpu_names():
+        arch = _arch_from_name(name)
+        if arch is not None:
+            return arch
+
+    return None
+
+
+def gfx_version(arch: str) -> int:
+    """``"gfx1030"`` -> ``0x1030``. Returns ``0`` when unparseable."""
+
+    digits = ""
+    for char in arch[3:]:
+        if char in "0123456789abcdef":
+            digits += char
+        else:
+            break
+    try:
+        return int(digits, 16)
+    except ValueError:
+        return 0
+
+
+# endregion
+
+
+# region ROCm wheel index
+
+
+#: ``gfx`` family -> path on https://rocm.nightlies.amd.com
+#: Mirrors the families AMD publishes PyTorch wheels for.
+def therock_family(arch: str | None) -> str | None:
+    if not arch:
+        return None
+
+    version = gfx_version(arch)
+
+    if (version & 0xFFF0) == 0x1200:
+        return "v2/gfx120X-all"
+    if (version & 0xFFF0) == 0x1100:
+        return "v2/gfx110X-all"
+    if version == 0x1151:
+        return "v2/gfx1151"
+    if version == 0x1150:
+        return "v2-staging/gfx1150"
+    if version in (0x1152, 0x1153):
+        return "v2-staging/gfx115X"
+    if version in (0x1030, 0x1031, 0x1032, 0x1034):
+        # RDNA 2 desktop: RX 6800/6900, RX 6700, RX 6600, RX 6500
+        return "v2-staging/gfx103X-dgpu"
+
+    return None
+
+
+def rocm_index_url(arch: str | None = None) -> str | None:
+    explicit = os.environ.get("ROCM_INDEX_URL")
+    if explicit:
+        return explicit.rstrip("/") + "/"
+
+    family = therock_family(arch if arch is not None else amd_arch())
+    if family is None:
+        return None
+
+    return f"https://rocm.nightlies.amd.com/{family}/"
+
+
+# endregion
+
+
+# region Selection
+
+
+def installed_backend() -> str | None:
+    """Backend implied by the PyTorch build that is currently installed."""
+
+    try:
+        import torch
+    except Exception:
+        return None
+
+    if getattr(torch.version, "hip", None):
+        return Backend.ROCM
+
+    try:
+        import torch_directml  # noqa: F401
+    except Exception:
+        pass
+    else:
+        if os.environ.get("SD_GPU_BACKEND") == Backend.DIRECTML:
+            return Backend.DIRECTML
+
+    if getattr(torch.version, "cuda", None):
+        return Backend.ZLUDA if is_zluda_runtime() else Backend.CUDA
+
+    return Backend.CPU
+
+
+def is_zluda_runtime() -> bool:
+    """True when the loaded CUDA runtime is actually ZLUDA."""
+
+    if os.environ.get("SD_ZLUDA_ACTIVE") == "1":
+        return True
+
+    try:
+        import torch
+    except Exception:
+        return False
+
+    try:
+        name = torch.cuda.get_device_name(torch.cuda.current_device())
+    except Exception:
+        return False
+
+    return "[ZLUDA]" in name
+
+
+def select_backend(requested: str | None = None) -> str:
+    """
+    Resolve the backend to install/run for.
+
+    ``requested`` comes from ``--gpu-backend`` / ``$SD_GPU_BACKEND``; ``auto``
+    (or ``None``) picks the best option for the detected hardware.
+    """
+
+    requested = (requested or os.environ.get("SD_GPU_BACKEND") or "auto").strip().lower()
+
+    if requested in Backend.ALL:
+        return requested
+
+    if requested not in ("auto", ""):
+        raise ValueError(f"Unknown GPU backend {requested!r}; expected one of {', '.join(Backend.ALL)} or auto")
+
+    # An existing install wins, so that re-launching never silently swaps the
+    # whole PyTorch stack underneath the user.
+    already = installed_backend()
+    if already is not None and already != Backend.CPU:
+        return already
+
+    if has_nvidia_gpu():
+        return Backend.CUDA
+
+    if has_amd_gpu():
+        if not IS_WINDOWS:
+            return Backend.ROCM
+        # Windows: prefer native ROCm wheels when AMD publishes them for this
+        # architecture, otherwise fall back to ZLUDA (needs the HIP SDK).
+        if rocm_index_url() is not None:
+            return Backend.ROCM
+        if hip_sdk_path() is not None:
+            return Backend.ZLUDA
+        return Backend.ROCM
+
+    return Backend.CPU
+
+
+@functools.cache
+def hip_sdk_path() -> str | None:
+    """Installation root of the AMD HIP SDK / ROCm, if present."""
+
+    explicit = os.environ.get("HIP_PATH")
+    if explicit and os.path.exists(explicit):
+        return explicit
+
+    if IS_WINDOWS:
+        root = os.path.join(os.environ.get("ProgramFiles", r"C:\Program Files"), "AMD", "ROCm")
+        if not os.path.isdir(root):
+            return None
+
+        def key(name: str):
+            try:
+                return tuple(int(part) for part in name.split("."))
+            except ValueError:
+                return ()
+
+        versions = sorted((name for name in os.listdir(root) if key(name)), key=key)
+        if not versions:
+            return None
+        return os.path.join(root, versions[-1])
+
+    return "/opt/rocm" if os.path.exists("/opt/rocm") else None
+
+
+def hip_sdk_version() -> tuple[int, int] | None:
+    path = hip_sdk_path()
+    if path is None:
+        return None
+    name = os.path.basename(path.rstrip("/\\"))
+    try:
+        major, minor = (int(part) for part in name.split(".")[:2])
+    except ValueError:
+        return None
+    return (major, minor)
+
+
+def describe() -> str:
+    payload = {
+        "gpus": list(list_gpu_names()),
+        "amd_arch": amd_arch(),
+        "hip_agents": list(hip_agents()),
+        "hip_sdk": hip_sdk_path(),
+        "rocm_index": rocm_index_url(),
+    }
+    return json.dumps(payload, indent=2)
+
+
+# endregion
+
+
+if __name__ == "__main__":
+    print(describe())
+    print("selected backend:", select_backend())

--- a/modules_forge/initialization.py
+++ b/modules_forge/initialization.py
@@ -27,10 +27,27 @@ def initialize_forge():
     sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "modules_forge", "packages"))
 
     from backend.args import args
+    from modules_forge import gpu_backend
+
+    backend = gpu_backend.select_backend(args.gpu_backend)
+    os.environ["SD_GPU_BACKEND"] = backend
 
     if args.gpu_device_id is not None:
+        # ROCm reads HIP_VISIBLE_DEVICES; it honours CUDA_VISIBLE_DEVICES too,
+        # but ZLUDA and the HIP runtime only look at the HIP variables.
         os.environ["CUDA_VISIBLE_DEVICES"] = str(args.gpu_device_id)
+        os.environ["HIP_VISIBLE_DEVICES"] = str(args.gpu_device_id)
+        os.environ["ROCR_VISIBLE_DEVICES"] = str(args.gpu_device_id)
         print("Set device to:", args.gpu_device_id)
+
+    zluda_ready = False
+    if backend == gpu_backend.Backend.ZLUDA:
+        from modules_forge import zluda_installer
+
+        # Has to happen before `import torch`, so that the CUDA libraries the
+        # wheel would otherwise bind to resolve to ZLUDA's implementations.
+        zluda_installer.load()
+        zluda_ready = True
 
     from modules_forge.cuda_malloc import (
         get_torch_version,
@@ -59,6 +76,14 @@ def initialize_forge():
     import torchvision  # noqa: F401
 
     startup_timer.record("import torch")
+
+    if zluda_ready:
+        from modules_forge import zluda
+
+        if not zluda.initialize():
+            raise RuntimeError("ZLUDA could not run a trivial matmul on your GPU. See AMD.md for troubleshooting.")
+
+        startup_timer.record("initialize zluda")
 
     device = memory_management.get_torch_device()
     torch.zeros((1, 1)).to(device, torch.float32)

--- a/modules_forge/zluda.py
+++ b/modules_forge/zluda.py
@@ -1,0 +1,56 @@
+"""Runtime patches applied to PyTorch when running on top of ZLUDA."""
+
+import torch
+
+from modules_forge import zluda_installer
+
+
+def _noop(*args, **kwargs):
+    return None
+
+
+def test(device: torch.device) -> Exception | None:
+    """Basic sanity check; ZLUDA fails loudly here rather than mid-generation."""
+
+    try:
+        a = torch.randn((2, 4), device=device)
+        b = torch.randn((4, 8), device=device)
+        assert torch.mm(a, b).sum().is_nonzero()
+    except Exception as e:
+        return e
+    return None
+
+
+def initialize() -> bool:
+    """
+    Disable every CUDA feature ZLUDA does not implement.
+
+    Returns ``False`` when the device fails the sanity check, in which case the
+    caller should fall back to the CPU instead of crashing later.
+    """
+
+    torch.backends.cudnn.enabled = zluda_installer.MIOpen_enabled
+
+    if hasattr(torch.backends.cuda, "enable_cudnn_sdp"):
+        if not zluda_installer.MIOpen_enabled:
+            torch.backends.cuda.enable_cudnn_sdp(False)
+            torch.backends.cuda.enable_cudnn_sdp = _noop
+    else:
+        torch.backends.cuda.enable_cudnn_sdp = _noop
+
+    # Neither FlashAttention nor the memory-efficient CUDA kernels exist under
+    # ZLUDA; leaving them enabled makes SDPA fall over instead of using math.
+    torch.backends.cuda.enable_flash_sdp(False)
+    torch.backends.cuda.enable_flash_sdp = _noop
+    torch.backends.cuda.enable_mem_efficient_sdp(False)
+    torch.backends.cuda.enable_mem_efficient_sdp = _noop
+    torch.backends.cuda.enable_math_sdp(True)
+
+    device = torch.device(torch.cuda.current_device())
+    error = test(device)
+    if error is not None:
+        print(f"ZLUDA: device failed the basic operation test (index={device.index})")
+        print(error)
+        return False
+
+    return True

--- a/modules_forge/zluda_installer.py
+++ b/modules_forge/zluda_installer.py
@@ -1,0 +1,206 @@
+"""
+ZLUDA support (Windows + AMD only).
+
+ZLUDA is a drop-in implementation of the CUDA driver API on top of AMD's HIP
+runtime, which lets the regular CUDA builds of PyTorch run on Radeon cards.
+It is the fallback for AMD GPUs that AMD does not publish native ROCm wheels
+for, and requires the AMD HIP SDK (6.2 or 6.4) to be installed.
+
+Reference: https://github.com/lshqqytiger/ZLUDA
+"""
+
+import ctypes
+import os
+import shutil
+import site
+import sys
+import zipfile
+
+from modules_forge import gpu_backend
+
+#: ZLUDA ships CUDA libraries under their unsuffixed names; PyTorch looks them
+#: up under the names the CUDA 11.x redistributables use.
+DLL_MAPPING: dict[str, str] = {
+    "cublas.dll": "cublas64_11.dll",
+    "cusparse.dll": "cusparse64_11.dll",
+    "cufft.dll": "cufft64_10.dll",
+    "cufftw.dll": "cufftw64_10.dll",
+    "nvrtc.dll": "nvrtc64_112_0.dll",
+}
+
+#: HIP SDK libraries that must be resident before ZLUDA is initialised.
+HIPSDK_TARGETS: tuple[str, ...] = ("rocblas.dll", "rocsolver.dll", "rocsparse.dll", "hipfft.dll")
+
+#: Pinned ZLUDA build. Override with `set ZLUDA_HASH=...` to move to another one.
+DEFAULT_COMMIT = "5e717459179dc272b7d7d23391f0fad66c7459cf"
+
+path: str = os.path.abspath(os.environ.get("ZLUDA", ".zluda"))
+
+MIOpen_enabled: bool = False
+hipBLASLt_enabled: bool = False
+nightly: bool = False
+
+
+class _Result(ctypes.Structure):
+    _fields_ = [("return_code", ctypes.c_int), ("value", ctypes.c_ulonglong)]
+
+
+def is_available() -> bool:
+    return sys.platform == "win32" and gpu_backend.hip_sdk_path() is not None
+
+
+def hip_sdk_major() -> int:
+    version = gpu_backend.hip_sdk_version()
+    return version[0] if version else 6
+
+
+def download_url(use_nightly: bool = False) -> str:
+    commit = os.environ.get("ZLUDA_HASH", DEFAULT_COMMIT)
+    platform = "nightly-windows" if use_nightly else "windows"
+    return f"https://github.com/lshqqytiger/ZLUDA/releases/download/rel.{commit}/ZLUDA-{platform}-rocm{hip_sdk_major()}-amd64.zip"
+
+
+def is_installed() -> bool:
+    return os.path.isfile(os.path.join(path, "nvcuda.dll"))
+
+
+def install(use_nightly: bool = False):
+    """Download and unpack ZLUDA into ``.zluda`` (no-op when already present)."""
+
+    if is_installed():
+        return
+
+    import urllib.request
+
+    url = download_url(use_nightly)
+    archive = os.path.join(os.path.dirname(path) or ".", "_zluda.zip")
+
+    print(f"Downloading ZLUDA from {url}")
+    urllib.request.urlretrieve(url, archive)
+
+    try:
+        with zipfile.ZipFile(archive, "r") as zf:
+            for info in zf.infolist():
+                if info.is_dir():
+                    continue
+                info.filename = os.path.basename(info.filename)
+                zf.extract(info, path)
+    finally:
+        try:
+            os.remove(archive)
+        except OSError:
+            pass
+
+    print(f"ZLUDA installed to {path}")
+
+
+def uninstall():
+    if os.path.exists(path):
+        shutil.rmtree(path)
+
+
+def _link_or_copy(src: str, dst: str):
+    for attempt in (os.symlink, os.link, shutil.copyfile):
+        try:
+            attempt(src, dst)
+        except Exception:
+            continue
+        else:
+            return
+    raise RuntimeError(f"Could not create {dst}")
+
+
+def _torch_lib_dir() -> str | None:
+    candidates = [p for p in site.getsitepackages() if p.endswith("site-packages")] or list(site.getsitepackages())
+    for base in candidates:
+        lib = os.path.join(base, "torch", "lib")
+        if os.path.isdir(lib):
+            return lib
+    return None
+
+
+def load():
+    """
+    Make the ZLUDA CUDA runtime the one PyTorch will bind to.
+
+    Must be called *before* ``import torch``.
+    """
+
+    global MIOpen_enabled, hipBLASLt_enabled, nightly
+
+    hip_root = gpu_backend.hip_sdk_path()
+    if hip_root is None:
+        raise RuntimeError("The AMD HIP SDK was not found. Install HIP SDK 6.2 (or 6.4) from https://www.amd.com/en/developer/resources/rocm-hub/hip-sdk.html")
+
+    if not is_installed():
+        raise RuntimeError(f"ZLUDA is not installed in {path}")
+
+    core = ctypes.windll.LoadLibrary(os.path.join(path, "nvcuda.dll"))
+    core.zluda_get_hip_object.restype = _Result
+    core.zluda_get_hip_object.argtypes = [ctypes.c_void_p, ctypes.c_int]
+    ctypes.windll.LoadLibrary(os.path.join(path, "nvml.dll"))
+
+    try:
+        core.zluda_get_nightly_flag.restype = ctypes.c_int
+        core.zluda_get_nightly_flag.argtypes = []
+        nightly = core.zluda_get_nightly_flag() == 1
+    except AttributeError:
+        nightly = False
+
+    hip_bin = os.path.join(hip_root, "bin")
+    blaslt_library = os.environ.get("HIPBLASLT_TENSILE_LIBPATH", os.path.join(hip_bin, "hipblaslt", "library"))
+    arch = gpu_backend.amd_arch() or ""
+
+    hipBLASLt_enabled = nightly and os.path.isfile(os.path.join(hip_bin, "hipblaslt.dll")) and os.path.isfile(os.path.join(blaslt_library, f"TensileLibrary_lazy_{arch}.dat"))
+    MIOpen_enabled = nightly and os.path.isfile(os.path.join(hip_bin, "MIOpen.dll"))
+
+    for source, alias in DLL_MAPPING.items():
+        if not os.path.exists(os.path.join(path, alias)):
+            _link_or_copy(os.path.join(path, source), os.path.join(path, alias))
+
+    if hipBLASLt_enabled and not os.path.exists(os.path.join(path, "cublasLt64_11.dll")):
+        _link_or_copy(os.path.join(path, "cublasLt.dll"), os.path.join(path, "cublasLt64_11.dll"))
+
+    if MIOpen_enabled and not os.path.exists(os.path.join(path, "cudnn64_9.dll")):
+        _link_or_copy(os.path.join(path, "cudnn.dll"), os.path.join(path, "cudnn64_9.dll"))
+
+    os.environ["PATH"] = path + os.pathsep + hip_bin + os.pathsep + os.environ.get("PATH", "")
+    for directory in (path, hip_bin):
+        try:
+            os.add_dll_directory(directory)
+        except (AttributeError, OSError):
+            pass
+
+    os.environ.setdefault("ZLUDA_COMGR_LOG_LEVEL", "1")
+
+    torch_lib = _torch_lib_dir()
+    if torch_lib is not None:
+        os.environ["ZLUDA_NVRTC_LIB"] = os.path.join(torch_lib, "nvrtc64_112_0.dll")
+
+    # Preloading by full path registers the module under its base name, so the
+    # later lookups performed by `torch` resolve to ZLUDA instead of the CUDA
+    # redistributables that ship inside the wheel.
+    for library in HIPSDK_TARGETS:
+        candidate = os.path.join(hip_bin, library)
+        if os.path.isfile(candidate):
+            ctypes.windll.LoadLibrary(candidate)
+
+    for alias in DLL_MAPPING.values():
+        ctypes.windll.LoadLibrary(os.path.join(path, alias))
+
+    if hipBLASLt_enabled:
+        os.environ.setdefault("DISABLE_ADDMM_CUDA_LT", "0")
+        ctypes.windll.LoadLibrary(os.path.join(hip_bin, "hipblaslt.dll"))
+        ctypes.windll.LoadLibrary(os.path.join(path, "cublasLt64_11.dll"))
+    else:
+        # cublasLt is not implemented without the nightly build; the ADDMM path
+        # that uses it would otherwise crash.
+        os.environ["DISABLE_ADDMM_CUDA_LT"] = "1"
+
+    if MIOpen_enabled:
+        ctypes.windll.LoadLibrary(os.path.join(hip_bin, "MIOpen.dll"))
+        ctypes.windll.LoadLibrary(os.path.join(path, "cudnn64_9.dll"))
+
+    os.environ["SD_ZLUDA_ACTIVE"] = "1"
+
+    print(f"ZLUDA: path='{path}' nightly={nightly} hipBLASLt={hipBLASLt_enabled} MIOpen={MIOpen_enabled}")

--- a/webui-user-amd.bat
+++ b/webui-user-amd.bat
@@ -1,0 +1,46 @@
+@echo off
+
+:: ===========================================================================
+::  Launcher for AMD Radeon GPUs on Windows.
+::
+::  Tested target: Radeon RX 6800 (gfx1030, 16 GB) / Ryzen 5 3600 / 64 GB RAM
+::                 / Windows 10 x64
+::
+::  Requirements:
+::    * Python 3.13 (or 3.12) 64-bit, "Add python.exe to PATH" ticked
+::    * Git for Windows
+::    * A current AMD Adrenalin driver
+::
+::  The first launch downloads a ROCm build of PyTorch (a few GB) and creates
+::  the "venv" folder. Read AMD.md if anything goes wrong.
+:: ===========================================================================
+
+:: Leave blank to use whatever "python" resolves to, or point at a specific
+:: interpreter, e.g. set PYTHON="C:\Users\%USERNAME%\AppData\Local\Programs\Python\Python313\python.exe"
+:: set PYTHON=
+:: set GIT=
+:: set VENV_DIR=
+
+:: --gpu-backend rocm     native ROCm PyTorch (recommended for RX 6800)
+:: --pin-shared-memory    use the 64 GB of system RAM to hold offloaded weights
+set COMMANDLINE_ARGS=--gpu-backend rocm --pin-shared-memory
+
+:: ---------------------------------------------------------------------------
+::  Other options worth knowing about
+:: ---------------------------------------------------------------------------
+:: --gpu-backend zluda      fall back to ZLUDA (needs the AMD HIP SDK 6.2/6.4);
+::                          use this if the ROCm wheels do not cover your card
+:: --zluda-nightly          ZLUDA nightly: adds hipBLASLt and MIOpen support
+:: --cuda-stream 2          overlap weight transfers with compute
+:: --lowvram / --novram     more aggressive offloading for very large models
+:: --reserve-vram 1.0       leave 1 GB of VRAM for the desktop compositor
+:: --use-pytorch-cross-attention   SDPA instead of the sliced fallback: faster
+::                          at low resolutions, more VRAM-hungry at high ones
+:: --fp16-unet              force fp16 weights (RDNA 2 has no fast bf16)
+:: --disable-gpu-warning    silence the low-VRAM warnings
+:: --reinstall-torch        rebuild the PyTorch install from scratch
+::
+:: NOT usable on AMD (they are CUDA-only and will be ignored with a message):
+::   --xformers --sage --flash --nunchaku --onnxruntime-gpu --cuda-malloc
+
+call webui.bat

--- a/webui-user.bat
+++ b/webui-user.bat
@@ -10,4 +10,9 @@ set COMMANDLINE_ARGS=
 :: --pin-shared-memory --cuda-malloc --cuda-stream
 :: --skip-python-version-check --skip-torch-cuda-test --skip-version-check --skip-prepare-environment --skip-install
 
+:: The compute backend is auto-detected. To pin it:
+:: --gpu-backend cuda | rocm | zluda | directml | cpu
+::
+:: AMD Radeon users: run webui-user-amd.bat instead, and see AMD.md
+
 call webui.bat

--- a/webui-user.sh
+++ b/webui-user.sh
@@ -10,4 +10,8 @@ export COMMANDLINE_ARGS="--uv"
 
 # --skip-python-version-check --skip-torch-cuda-test --skip-version-check --skip-prepare-environment --skip-install
 
+# The compute backend is auto-detected; pin it with
+#   --gpu-backend cuda | rocm | cpu
+# AMD Radeon on Linux uses the "rocm" backend; see AMD.md.
+
 exec "$(dirname "$0")/webui.sh"

--- a/webui.bat
+++ b/webui.bat
@@ -4,7 +4,6 @@ if exist webui.settings.bat (
     call webui.settings.bat
 )
 
-if not defined PYTHON (set PYTHON=python)
 if defined GIT (set "GIT_PYTHON_GIT_EXECUTABLE=%GIT%")
 if not defined VENV_DIR (set "VENV_DIR=%~dp0%venv")
 
@@ -13,12 +12,44 @@ set ERROR_REPORTING=FALSE
 
 mkdir tmp 2>NUL
 
+if not defined PYTHON (set PYTHON=python)
+
 uv help python >tmp/stdout.txt 2>tmp/stderr.txt
 if %ERRORLEVEL% == 0 goto :check_pip
+
+if not "%PYTHON%" == "python" goto :verify_python
+
+:: Prefer an interpreter this program actually supports. "python" on a fresh
+:: Windows 10 box is often the Microsoft Store stub, or a version PyTorch has
+:: no wheels for, so fall back to the "py" launcher when it isn't suitable.
+call :is_supported_python python && goto :verify_python
+
+for %%v in (3.13 3.12) do (
+    call :is_supported_python "py -%%v" && (
+        set "PYTHON=py -%%v"
+        goto :verify_python
+    )
+)
+
+set PYTHON=python
+
+:verify_python
 %PYTHON% -c "" >tmp/stdout.txt 2>tmp/stderr.txt
-if %ERRORLEVEL% == 0 goto :check_pip
+if %ERRORLEVEL% == 0 goto :check_arch
 echo Couldn't launch python
+echo.
+echo Install 64-bit Python 3.13 from https://www.python.org/downloads/
+echo and make sure "Add python.exe to PATH" is ticked during setup.
 goto :show_stdout_stderr
+
+:check_arch
+%PYTHON% -c "import struct,sys; sys.exit(0 if struct.calcsize('P')==8 else 1)" >nul 2>&1
+if %ERRORLEVEL% == 0 goto :check_pip
+echo.
+echo This Python is 32-bit. PyTorch (both the NVIDIA and the AMD/ROCm builds)
+echo only ships 64-bit Windows wheels. Install 64-bit Python 3.13 and delete
+echo the "venv" folder before retrying.
+goto :endofscript
 
 :check_pip
 uv help pip >tmp/stdout.txt 2>tmp/stderr.txt
@@ -61,6 +92,11 @@ if EXIST tmp/restart goto :skip_venv
 pause
 exit /b
 
+:: Succeeds when %~1 is a working interpreter of a version we ship wheels for.
+:is_supported_python
+%~1 -c "import sys; sys.exit(0 if sys.version_info[:2] in ((3,13),(3,12)) else 1)" >nul 2>&1
+exit /b %ERRORLEVEL%
+
 :show_stdout_stderr
 
 echo.
@@ -74,7 +110,7 @@ type tmp\stdout.txt
 
 :show_stderr
 for /f %%i in ("tmp\stderr.txt") do set size=%%~zi
-if %size% equ 0 goto :show_stderr
+if %size% equ 0 goto :endofscript
 echo.
 echo stderr:
 type tmp\stderr.txt


### PR DESCRIPTION
The installer hardcoded CUDA 13 PyTorch wheels, so the bat launcher could only ever produce a working install on NVIDIA hardware. The runtime already carried most of ComfyUI's ROCm handling, but nothing selected or installed a PyTorch build that would activate it.

Installer
- modules_forge/gpu_backend.py: stdlib-only detection of the installed GPU, its LLVM gfx target (via the HIP runtime that ships with the Adrenalin driver, falling back to a marketing-name table) and the matching wheel index. Selects cuda/rocm/zluda/directml/cpu, and never swaps the backend out from under an existing install.
- prepare_environment() installs the PyTorch build the selected backend needs: TheRock ROCm wheels on Windows, download.pytorch.org/whl/rocm on Linux, cu118 for ZLUDA, cpu wheels otherwise.
- CUDA-only extras (xformers, sageattention, flash_attn, nunchaku, onnxruntime-gpu) are skipped with a message instead of failing the install.
- Warn when a later install step replaces PyTorch with a mismatched build.
- Accept Python 3.12 as well as 3.13, since the AMD wheels are cp312/cp313.

ZLUDA
- modules_forge/zluda_installer.py downloads ZLUDA and binds its CUDA libraries ahead of `import torch`; modules_forge/zluda.py disables the CUDA features it does not implement and sanity-checks the device.

Runtime
- memory_management: detect ZLUDA, so is_nvidia()/is_amd() report the real hardware; resolve the gfx target without gcnArchName; keep fp16 (RDNA 2 has no fast bf16); skip pinned memory and IPC where unimplemented.
- Restrict SDPA to the math backend on RDNA 2 and ZLUDA, which have no FlashAttention kernels, and keep the batch limit chunked so the O(N^2) fallback does not blow up 16 GB cards.
- cuda_malloc: no-op on ROCm and ZLUDA rather than corrupting the allocator.
- Map --gpu-device-id onto HIP_VISIBLE_DEVICES/ROCR_VISIBLE_DEVICES too.

Launchers & docs
- webui-user-amd.bat: ready-made launcher tuned for a 16 GB Radeon with plenty of system RAM.
- webui.bat: pick a supported 64-bit interpreter via the py launcher instead of assuming `python`, and fix the infinite loop in the error path.
- AMD.md documents the backends, precision and attention behaviour on RDNA 2, large-model (GGUF/fp8) handling and troubleshooting.
- sysinfo dumps the detected backend, GPU architecture and PyTorch build.


Claude-Session: https://claude.ai/code/session_01NhQtvbRpEpACDRxpNZVrfu