### PR TITLE
Legacy NVIDIA GPUs (Pascal etc.): cu126 PyTorch + account for VRAM used by other processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,20 @@ The name "Forge" is inspired by "Minecraft Forge". This project aims to become t
 
 <br>
 
+#### Legacy NVIDIA GPUs *(GTX 10xx / GTX 9xx / Titan V)*
+
+Maxwell, Pascal and Volta GPUs *(compute capability < 7.5)* are **not** supported by the CUDA 13 builds of PyTorch. On these cards, the launcher now detects the GPU *(via `nvidia-smi`)* and automatically installs the CUDA 12.6 build *(`torch==2.10.0+cu126`)* instead. `xformers`, `SageAttention` and `FlashAttention` are not available for these GPUs; the default PyTorch attention *(memory-efficient kernel)* is used.
+
+A few things to keep in mind on these cards:
+
+- **Use quantized weights:** for large models *(**Flux**, **Z-Image**, **Qwen-Image**)*, prefer `GGUF` *(`Q4_K_M` / `Q5_K_M`)* or `fp8` checkpoints; the `bnb-nf4` checkpoints from the original Forge are not supported anymore.
+- **VRAM used by other applications:** on Windows, the driver does not report the VRAM used by other processes *(browsers, desktop, etc.)* to CUDA; the WebUI now queries the driver directly *(**NVML**)* and takes it into account, otherwise the GPU gets oversubscribed and the driver starts paging VRAM to the system memory *(the speed drops by ~10x without any error)*. Closing GPU-hungry applications before generating helps on a 8 GB card.
+- **Reserve VRAM manually if needed:** lower **GPU Weights** in the *Settings*, or launch with **e.g.** `--reserve-vram 2`, to leave more room for the computation. This is the equivalent of the *GPU Weights* slider from the original Forge.
+- **Swapping:** `--cuda-stream` and `--pin-shared-memory` speed up the weight swapping from RAM; `--lowvram` is available as a last resort.
+- **Precision:** these GPUs have no `bf16` support; models that do not allow `fp16` are computed in `fp32`, so expect up to **2x** the activation memory compared to a modern GPU in that case. `fp16` matrix multiplications *(**Flux**, **Z-Image** `GGUF`)* run at the `fp32` speed via cuBLAS.
+
+<br>
+
 ## Attention Functions
 
 > [!Important]

--- a/backend/memory_management.py
+++ b/backend/memory_management.py
@@ -19,6 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+import ctypes
 import gc
 import importlib
 import logging
@@ -155,6 +156,81 @@ def get_torch_device() -> torch.device:
             return torch.device(torch.cuda.current_device())
 
 
+# region NVML
+
+_NVML = None  # ctypes handle to the NVML library ; False when unavailable
+_NVML_DEVICE_HANDLES: dict[int, ctypes.c_void_p] = {}
+
+
+class _NVMLMemory(ctypes.Structure):
+    _fields_ = [("total", ctypes.c_ulonglong), ("free", ctypes.c_ulonglong), ("used", ctypes.c_ulonglong)]
+
+
+def _nvml_library():
+    """Load NVML (shipped with the NVIDIA driver) via ctypes ; no Python dependency required"""
+    global _NVML
+    if _NVML is None:
+        _NVML = False
+        if is_nvidia():
+            names = ("nvml.dll",) if platform.system() == "Windows" else ("libnvidia-ml.so.1", "libnvidia-ml.so")
+            for name in names:
+                try:
+                    lib = ctypes.CDLL(name)
+                    if lib.nvmlInit_v2() == 0:
+                        _NVML = lib
+                        break
+                except (OSError, AttributeError):
+                    continue
+            if _NVML is False:
+                logger.debug("NVML is not available ; free VRAM is estimated by CUDA only")
+    return _NVML
+
+
+def _nvml_device_handle(dev: torch.device):
+    lib = _nvml_library()
+    if not lib:
+        return None
+
+    index = dev.index if dev.index is not None else torch.cuda.current_device()
+    if index not in _NVML_DEVICE_HANDLES:
+        handle = ctypes.c_void_p()
+        props = torch.cuda.get_device_properties(index)
+        found = False
+
+        # match the device by PCI bus id, as the NVML and CUDA device indices are not necessarily the same
+        if all(hasattr(props, attr) for attr in ("pci_domain_id", "pci_bus_id", "pci_device_id")):
+            bus_id = "{:08x}:{:02x}:{:02x}.0".format(props.pci_domain_id, props.pci_bus_id, props.pci_device_id)
+            found = lib.nvmlDeviceGetHandleByPciBusId_v2(bus_id.encode(), ctypes.byref(handle)) == 0
+        if not found:
+            found = lib.nvmlDeviceGetHandleByIndex_v2(index, ctypes.byref(handle)) == 0
+
+        _NVML_DEVICE_HANDLES[index] = handle if found else None
+    return _NVML_DEVICE_HANDLES[index]
+
+
+def nvml_free_memory(dev: torch.device) -> int | None:
+    """
+    Free VRAM as seen by the driver, accounting for **all** processes
+
+    On Windows (WDDM), `cudaMemGetInfo` does not account for the VRAM used by other processes
+    (browsers, the desktop, etc.), since the driver can evict their allocations; but once the GPU is
+    oversubscribed, the driver starts paging VRAM to the system memory and the speed drops by ~10x.
+    """
+    try:
+        handle = _nvml_device_handle(dev)
+        if handle is None:
+            return None
+        info = _NVMLMemory()
+        if _NVML.nvmlDeviceGetMemoryInfo(handle, ctypes.byref(info)) != 0:
+            return None
+        return int(info.free)
+    except Exception:
+        return None
+
+
+# endregion
+
+
 def get_total_memory(dev: torch.device = None, torch_total_too: bool = False):
     dev = dev or get_torch_device()
 
@@ -187,6 +263,13 @@ def get_total_memory(dev: torch.device = None, torch_total_too: bool = False):
 total_vram = get_total_memory(get_torch_device()) / (1024 * 1024)
 total_ram = psutil.virtual_memory().total / (1024 * 1024)
 logger.info("Total VRAM {:0.0f} MB, total RAM {:0.0f} MB".format(total_vram, total_ram))
+
+if is_nvidia():
+    _free_nvml = nvml_free_memory(get_torch_device())
+    if _free_nvml is not None:
+        _free_cuda, _ = torch.cuda.mem_get_info(get_torch_device())
+        if (_free_cuda - _free_nvml) > 256 * 1024 * 1024:
+            logger.info("VRAM used by other processes: {:0.0f} MB (not reported by CUDA ; taken into account)".format((_free_cuda - _free_nvml) / (1024 * 1024)))
 
 try:
     logger.info("PyTorch Version: {}".format(torch_version))
@@ -1124,6 +1207,8 @@ def get_free_memory(dev: torch.device = None, torch_free_too: bool = False) -> i
             mem_active = stats["active_bytes.all.current"]
             mem_reserved = stats["reserved_bytes.all.current"]
             mem_free_cuda, _ = torch.cuda.mem_get_info(dev)
+            if (mem_free_nvml := nvml_free_memory(dev)) is not None:
+                mem_free_cuda = min(mem_free_cuda, mem_free_nvml)
             mem_free_torch = mem_reserved - mem_active
             mem_free_total = mem_free_cuda + mem_free_torch
 

--- a/modules/errors.py
+++ b/modules/errors.py
@@ -106,7 +106,10 @@ def check_versions():
     outdated: list[str] = []
 
     if version.parse(torch.__version__) < version.parse(expected_torch):
-        outdated.append(f"You are running PyTorch {torch.__version__}, which is outdated.")
+        # Maxwell / Pascal / Volta (compute capability < 7.5) require the older CUDA 12.6 build of PyTorch
+        legacy_gpu = torch.cuda.is_available() and torch.cuda.get_device_capability() < (7, 5)
+        if not (legacy_gpu and "+cu126" in torch.__version__):
+            outdated.append(f"You are running PyTorch {torch.__version__}, which is outdated.")
 
     if shared.xformers_available:
         import xformers

--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -283,9 +283,43 @@ def requirements_met(requirements_file):
     return True
 
 
+def _nvidia_compute_capability() -> tuple[int, int] | None:
+    """Query the compute capability of the first NVIDIA GPU via `nvidia-smi`; returns None if unavailable"""
+    try:
+        result = subprocess.run(
+            ["nvidia-smi", "--query-gpu=compute_cap", "--format=csv,noheader"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    caps = []
+    for line in result.stdout.splitlines():
+        m = re.match(r"\s*(\d+)\.(\d+)", line)
+        if m is not None:
+            caps.append((int(m.group(1)), int(m.group(2))))
+    return min(caps) if caps else None
+
+
+def _is_legacy_nvidia_gpu() -> bool:
+    """Maxwell / Pascal / Volta (compute capability < 7.5) are not supported by the CUDA 13 (`cu130`) builds of PyTorch"""
+    cap = _nvidia_compute_capability()
+    return cap is not None and cap < (7, 5)
+
+
 def prepare_environment():
-    torch_index_url = os.environ.get("TORCH_INDEX_URL", "https://download.pytorch.org/whl/cu130")
-    torch_command = os.environ.get("TORCH_COMMAND", f"pip install torch==2.13.0+cu130 torchvision==0.28.0+cu130 --extra-index-url {torch_index_url}")
+    if "TORCH_COMMAND" not in os.environ and "TORCH_INDEX_URL" not in os.environ and _is_legacy_nvidia_gpu():
+        # PyTorch >= 2.8 only ships Maxwell / Pascal / Volta kernels in the `cu126` wheels
+        # https://github.com/pytorch/pytorch/issues/157517
+        print("Legacy NVIDIA GPU detected (compute capability < 7.5): using the CUDA 12.6 build of PyTorch")
+        torch_index_url = "https://download.pytorch.org/whl/cu126"
+        torch_command = f"pip install torch==2.10.0+cu126 torchvision==0.25.0+cu126 --extra-index-url {torch_index_url}"
+    else:
+        torch_index_url = os.environ.get("TORCH_INDEX_URL", "https://download.pytorch.org/whl/cu130")
+        torch_command = os.environ.get("TORCH_COMMAND", f"pip install torch==2.13.0+cu130 torchvision==0.28.0+cu130 --extra-index-url {torch_index_url}")
     xformers_package = os.environ.get("XFORMERS_PACKAGE", f"xformers==0.0.35 --extra-index-url {torch_index_url}")
 
     packaging_package = os.environ.get("PACKAGING_PACKAGE", "packaging==26.2")
@@ -325,12 +359,25 @@ cuda = hasattr(torch, "cuda") and torch.cuda.is_available()
 xpu = hasattr(torch, "xpu") and torch.xpu.is_available()
 mps = hasattr(torch, "mps") and torch.mps.is_available()
 assert cuda or xpu or mps
+if cuda:
+    # a build of PyTorch without kernels for this GPU still reports `cuda.is_available()`,
+    # but fails on the very first operation with "no kernel image is available"
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        (torch.ones(1, device="cuda") * 2).cpu()
         """
 
         success, err = check_run_python(TORCH_CHECK, return_error=True)
         if not success:
             if "older driver" in str(err).lower():
                 raise SystemError("Please update your GPU driver or manually install older version of PyTorch")
+            if "no kernel image" in str(err).lower():
+                raise SystemError(
+                    "The installed build of PyTorch does not support this GPU (Maxwell / Pascal / Volta are not supported by the CUDA 13 builds)\n"
+                    'Set "TORCH_COMMAND=pip install torch==2.10.0+cu126 torchvision==0.25.0+cu126 --extra-index-url https://download.pytorch.org/whl/cu126" '
+                    "and launch with --reinstall-torch"
+                )
             raise RuntimeError("PyTorch is not able to access any compute device (GPU)")
         startup_timer.record("torch GPU test")
 


### PR DESCRIPTION
Tested on a GTX 1070 8 GB (sm_61), Windows 11, Python 3.13.7, torch 2.10.0+cu126, with Flux.1-dev Q4_0 GGUF and Z-Image-Turbo Q4_K_M GGUF. Three small commits:

**1. Launcher: legacy GPUs (compute capability < 7.5)**
The cu128 / cu130 wheels have no kernels for Maxwell / Pascal / Volta (pytorch/pytorch#157517). The launcher now checks `nvidia-smi --query-gpu=compute_cap` and installs `torch==2.10.0+cu126` (the wiki combination) on these cards, unless `TORCH_COMMAND` / `TORCH_INDEX_URL` are set. The torch check also runs one real CUDA op, so a wrong build fails at startup with a clear message instead of "no kernel image is available" mid-generation. The "outdated PyTorch" warning is skipped for this case, since reinstalling the venv would bring cu130 back. Nothing changes for RTX 20xx and newer.

**2. Memory manager: VRAM used by other processes (Windows)**
On Windows, `cudaMemGetInfo()` does not include the VRAM held by other processes (browser, desktop, IDE...), so `get_free_memory()` over-reports and the manager fills the card. As soon as the sampling needs its working memory the driver starts paging to system RAM: no OOM, just ~8x slower. `get_free_memory()` now takes `min(cudaMemGetInfo, NVML)`; NVML is loaded from the driver via `ctypes`, no new dependency, silent fallback if unavailable. On Linux both values already agree, so no change there.

Flux.1-dev, 768x1024, 20 steps, `--cuda-stream --pin-shared-memory`, ~1.5 GB used by other apps:
| | weights on GPU | speed |
|---|---|---|
| before | 5699 MB | 130-170 s/it (VRAM at 7.8 GB, paging) |
| after, default settings | 4135 MB | 20.5 s/it |

**3. README** notes for these GPUs.

Not changed: the attention memory estimate. FlashAttention is missing on these cards, but the memory-efficient SDPA kernel works on sm_61, and the existing estimate matched the measured peak (~400 MB allocated above the weights for Flux 768x1024), so I left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
