### PR TITLE
Fix Anima LoRA layout detection for pre-remapped turbo LoRAs

### DIFF
--- a/extensions-builtin/sd_forge_lora/networks.py
+++ b/extensions-builtin/sd_forge_lora/networks.py
@@ -35,16 +35,14 @@ def process_anima(lora: dict[str, torch.Tensor], blocks: int) -> bool:
         elif k.startswith("lora_unet_llm_adapter"):
             lora[k.replace("lora_unet_llm_adapter", "lora_te_llm_adapter")] = lora.pop(k)
 
-    from modules_forge.packages.huggingface_guess.detection import count_blocks
+    prefix = "lora_unet_blocks_" if any(k.startswith("lora_unet_blocks_") for k in keys) else "diffusion_model.blocks."
+    pattern = re.compile(re.escape(prefix) + r"(\d+)\.")
+    indices = [int(m.group(1)) for k in keys for m in [pattern.match(k)] if m]
 
-    lora_blocks: int = count_blocks(lora, "lora_unet_blocks_" + "{}") or count_blocks(lora, "diffusion_model.blocks." + "{}")
-
-    if lora_blocks < 28:
-        if blocks == 28:
-            return True
-        else:
-            logger.warning("Assuming LoRA is for 2B Model...")
-            lora_blocks = 28
+    # count_blocks breaks on pre-remapped LoRAs that skip blocks (e.g. 2.9B Turbo),
+    # so derive the layout from the highest block index snapped up to a known size
+    lora_blocks: int = (max(indices) + 1) if indices else 0
+    lora_blocks = next((size for size in (28, 40, 52) if lora_blocks <= size), lora_blocks)
 
     if lora_blocks == blocks:
         return True
@@ -73,14 +71,13 @@ def process_anima(lora: dict[str, torch.Tensor], blocks: int) -> bool:
         return False
 
     logger.warning(f"Re-Mapping Anima LoRA ({lora_blocks} to {blocks})")
-    prefix = "lora_unet_blocks_" if any(k.startswith("lora_unet_blocks_") for k in keys) else "diffusion_model.blocks."
 
     for i in range(blocks):
-        a = f"{prefix}{mapping[i]}"
-        b = f"{prefix}{i}"
+        a = f"{prefix}{mapping[i]}."
+        b = f"{prefix}{i}."
 
         for k in keys:
-            if a in k:
+            if k.startswith(a):
                 lora[k.replace(a, b)] = temp[k].clone()
 
     del temp


### PR DESCRIPTION
## Problem

Pre-remapped Anima 2.9B turbo LoRAs (files already shipped in the 40-block layout with 12 blocks skipped, e.g. `Anima-2.9B_Turbo-BF16.safetensors` / `anima29b-turbo-v2.9-remap.safetensors`) silently stop working on Anima 2.9B since the Anima 3.8B rework (c5fb32f8 + 92b55e1b). The same file loads fine on e52cf9f2.

Console output when loading such a LoRA on 2.9B:

```
Assuming LoRA is for 2B Model...
Re-Mapping Anima LoRA (28 to 40)
```

## Root cause

`process_anima` measures the LoRA layout with `count_blocks`, which counts consecutive block indices from 0. The pre-remapped turbo files skip blocks (`2, 5, 8, ..., 36`), so `count_blocks` returns **5** and the file is misdetected as a 2B LoRA. It then gets remapped 28 -> 40 a **second** time:

- the already-correct block contents are scattered onto the wrong model blocks (turbo effect silently ruined)
- the substring source matching (`if a in k`) lets `blocks.1` match `blocks.1x`, generating keys for blocks that do not exist on the model (41-59)

Before e52cf9f2 these files loaded unchanged, because the old remap only touched `lora_unet_blocks_`-prefixed keys.

## Fix

- Derive the layout from the **highest block index**, snapped up to a known model size (28 / 40 / 52), instead of consecutive counting — gapped / pre-remapped layouts are then detected correctly.
- Match remap source keys with `startswith("<prefix><N>.")` so `blocks.1` can no longer match `blocks.10`.

## Verification

Tested against both turbo LoRA layout variants on all three model sizes:

| LoRA file layout | Model | After fix |
| --- | --- | --- |
| pre-remapped, gapped (28 of 40 blocks present) | 2.9B (40 blocks) | loads unchanged, same as e52cf9f2 |
| pre-remapped, gapped | 3.8B (52 blocks) | remapped 40 -> 52 |
| plain 28-block (0-27) | 2.9B (40 blocks) | remapped 28 -> 40 via `MAPPING_2_TO_29`, no phantom keys |
| plain 28-block | 2B (28 blocks) | loads unchanged |
| text-encoder-only | any | llm_adapter rename only, remap is a no-op |
