### PR TITLE
Fix Anima LoRA layout detection for pre-remapped and kohya-style LoRAs

### DIFF
--- a/extensions-builtin/sd_forge_lora/networks.py
+++ b/extensions-builtin/sd_forge_lora/networks.py
@@ -35,16 +35,14 @@ def process_anima(lora: dict[str, torch.Tensor], blocks: int) -> bool:
         elif k.startswith("lora_unet_llm_adapter"):
             lora[k.replace("lora_unet_llm_adapter", "lora_te_llm_adapter")] = lora.pop(k)
 
-    from modules_forge.packages.huggingface_guess.detection import count_blocks
+    prefix = "lora_unet_blocks_" if any(k.startswith("lora_unet_blocks_") for k in keys) else "diffusion_model.blocks."
+    pattern = re.compile(re.escape(prefix) + r"(\d+)\.")
+    indices = [int(m.group(1)) for k in keys for m in [pattern.match(k)] if m]
 
-    lora_blocks: int = count_blocks(lora, "lora_unet_blocks_" + "{}") or count_blocks(lora, "diffusion_model.blocks." + "{}")
-
-    if lora_blocks < 28:
-        if blocks == 28:
-            return True
-        else:
-            logger.warning("Assuming LoRA is for 2B Model...")
-            lora_blocks = 28
+    # count_blocks breaks on pre-remapped LoRAs that skip blocks (e.g. 2.9B Turbo),
+    # so derive the layout from the highest block index snapped up to a known size
+    lora_blocks: int = (max(indices) + 1) if indices else 0
+    lora_blocks = next((size for size in (28, 40, 52) if lora_blocks <= size), lora_blocks)
 
     if lora_blocks == blocks:
         return True
@@ -73,14 +71,13 @@ def process_anima(lora: dict[str, torch.Tensor], blocks: int) -> bool:
         return False
 
     logger.warning(f"Re-Mapping Anima LoRA ({lora_blocks} to {blocks})")
-    prefix = "lora_unet_blocks_" if any(k.startswith("lora_unet_blocks_") for k in keys) else "diffusion_model.blocks."
 
     for i in range(blocks):
-        a = f"{prefix}{mapping[i]}"
-        b = f"{prefix}{i}"
+        a = f"{prefix}{mapping[i]}."
+        b = f"{prefix}{i}."
 
         for k in keys:
-            if a in k:
+            if k.startswith(a):
                 lora[k.replace(a, b)] = temp[k].clone()
 
     del temp

--- a/extensions-builtin/sd_forge_lora/networks.py
+++ b/extensions-builtin/sd_forge_lora/networks.py
@@ -35,13 +35,20 @@ def process_anima(lora: dict[str, torch.Tensor], blocks: int) -> bool:
         elif k.startswith("lora_unet_llm_adapter"):
             lora[k.replace("lora_unet_llm_adapter", "lora_te_llm_adapter")] = lora.pop(k)
 
-    prefix = "lora_unet_blocks_" if any(k.startswith("lora_unet_blocks_") for k in keys) else "diffusion_model.blocks."
-    pattern = re.compile(re.escape(prefix) + r"(\d+)\.")
-    indices = [int(m.group(1)) for k in keys for m in [pattern.match(k)] if m]
+    # the block number sits between the prefix and the format's own separator:
+    # lora_unet_blocks_0_... (kohya) / diffusion_model.blocks.0.... (ComfyUI)
+    prefix, sep = ("lora_unet_blocks_", "_") if any(k.startswith("lora_unet_blocks_") for k in keys) else ("diffusion_model.blocks.", ".")
+    parsed: dict[str, tuple[int, str]] = {}
+    for k in keys:
+        if not k.startswith(prefix):
+            continue
+        num, s, tail = k[len(prefix) :].partition(sep)
+        if s and num.isdigit():
+            parsed[k] = (int(num), tail)
 
     # count_blocks breaks on pre-remapped LoRAs that skip blocks (e.g. 2.9B Turbo),
     # so derive the layout from the highest block index snapped up to a known size
-    lora_blocks: int = (max(indices) + 1) if indices else 0
+    lora_blocks: int = (max(n for n, _ in parsed.values()) + 1) if parsed else 0
     lora_blocks = next((size for size in (28, 40, 52) if lora_blocks <= size), lora_blocks)
 
     if lora_blocks == blocks:
@@ -52,7 +59,6 @@ def process_anima(lora: dict[str, torch.Tensor], blocks: int) -> bool:
         return False
 
     temp = lora.copy()
-    keys = list(temp.keys())
 
     MAPPING_2_TO_29 = [0, 1, 1, 2, 3, 3, 4, 5, 5, 6, 7, 7, 8, 9, 9, 10, 11, 11, 12, 13, 14, 14, 15, 16, 16, 17, 18, 18, 19, 20, 20, 21, 22, 22, 23, 24, 24, 25, 26, 27]
 
@@ -72,13 +78,13 @@ def process_anima(lora: dict[str, torch.Tensor], blocks: int) -> bool:
 
     logger.warning(f"Re-Mapping Anima LoRA ({lora_blocks} to {blocks})")
 
-    for i in range(blocks):
-        a = f"{prefix}{mapping[i]}."
-        b = f"{prefix}{i}."
+    reverse: dict[int, list[int]] = {}
+    for target, source in enumerate(mapping):
+        reverse.setdefault(source, []).append(target)
 
-        for k in keys:
-            if k.startswith(a):
-                lora[k.replace(a, b)] = temp[k].clone()
+    for k, (source, tail) in parsed.items():
+        for target in reverse.get(source, []):
+            lora[f"{prefix}{target}{sep}{tail}"] = temp[k].clone()
 
     del temp
     return True

--- a/extensions-builtin/sd_forge_lora/networks.py
+++ b/extensions-builtin/sd_forge_lora/networks.py
@@ -35,10 +35,9 @@ def process_anima(lora: dict[str, torch.Tensor], blocks: int) -> bool:
         elif k.startswith("lora_unet_llm_adapter"):
             lora[k.replace("lora_unet_llm_adapter", "lora_te_llm_adapter")] = lora.pop(k)
 
-    # the block number sits between the prefix and the format's own separator:
-    # lora_unet_blocks_0_... (kohya) / diffusion_model.blocks.0.... (ComfyUI)
-    prefix, sep = ("lora_unet_blocks_", "_") if any(k.startswith("lora_unet_blocks_") for k in keys) else ("diffusion_model.blocks.", ".")
     parsed: dict[str, tuple[int, str]] = {}
+    prefix, sep = ("lora_unet_blocks_", "_") if any(k.startswith("lora_unet_blocks_") for k in keys) else ("diffusion_model.blocks.", ".")
+
     for k in keys:
         if not k.startswith(prefix):
             continue
@@ -46,10 +45,8 @@ def process_anima(lora: dict[str, torch.Tensor], blocks: int) -> bool:
         if s and num.isdigit():
             parsed[k] = (int(num), tail)
 
-    # count_blocks breaks on pre-remapped LoRAs that skip blocks (e.g. 2.9B Turbo),
-    # so derive the layout from the highest block index snapped up to a known size
-    lora_blocks: int = (max(n for n, _ in parsed.values()) + 1) if parsed else 0
-    lora_blocks = next((size for size in (28, 40, 52) if lora_blocks <= size), lora_blocks)
+    _blocks: int = (max(n for n, _ in parsed.values()) + 1) if parsed else 0
+    lora_blocks: int = next(size for size in (28, 40, 52) if _blocks <= size)
 
     if lora_blocks == blocks:
         return True
@@ -79,6 +76,7 @@ def process_anima(lora: dict[str, torch.Tensor], blocks: int) -> bool:
     logger.warning(f"Re-Mapping Anima LoRA ({lora_blocks} to {blocks})")
 
     reverse: dict[int, list[int]] = {}
+
     for target, source in enumerate(mapping):
         reverse.setdefault(source, []).append(target)
 


### PR DESCRIPTION
Replaces #1452 (auto-closed when the fork branch was removed).

## Problem

Two regressions in `process_anima` since the Anima 3.8B rework (c5fb32f8 + 92b55e1b), both visible on Anima 2.9B (40 blocks):

1. **Pre-remapped turbo LoRAs stop working.** Files already shipped in the 40-block layout with 12 blocks skipped (e.g. `Anima-2.9B_Turbo-BF16.safetensors`, missing blocks `2, 5, 8, ..., 36`) make `count_blocks` return **5** — the file is misdetected as a 2B LoRA, gets remapped 28 -> 40 a *second* time, and the scrambled block assignment silently ruins the LoRA. The substring matching (`if a in k`) even produces keys for blocks 41-59, which no model has. Loading such a LoRA logs:

```
Assuming LoRA is for 2B Model...
Re-Mapping Anima LoRA (28 to 40)
```

2. **Kohya-style keys are not remapped.** LoRAs trained with kohya (`lora_unet_blocks_0_cross_attn_k_proj.lora_down.weight`, underscore separator) are only matched against the `diffusion_model.blocks.` prefix logic, so a 2B-trained LoRA lands on the first 28 of the 40 model blocks and the effect is heavily diluted.

Both worked on e52cf9f2 (the old remap only touched `lora_unet_blocks_` keys via substring matching).

## Fix

- Derive the LoRA layout from the **highest block index**, snapped up to a known model size (28 / 40 / 52), instead of `count_blocks` consecutive counting — gapped / pre-remapped layouts are then detected correctly.
- Parse the block number with plain string operations between the key prefix and the format's own separator (`lora_unet_blocks_0_...` for kohya, `diffusion_model.blocks.0....` for ComfyUI), and rewrite it through a source -> targets reverse map. Exact matching also keeps `blocks.1` from matching `blocks.10` in either format.

## Verification

| LoRA file layout | Model | After fix |
| --- | --- | --- |
| pre-remapped, gapped (28 of 40 blocks present) | 2.9B (40 blocks) | loads unchanged, same as e52cf9f2 |
| pre-remapped, gapped | 3.8B (52 blocks) | remapped 40 -> 52 |
| plain 28-block ComfyUI (0-27, dotted keys) | 2.9B (40 blocks) | remapped 28 -> 40 via `MAPPING_2_TO_29`, no phantom keys |
| plain 28-block kohya (underscore keys) | 2.9B (40 blocks) | remapped 28 -> 40, underscore keys preserved |
| plain 28-block | 2B (28 blocks) | loads unchanged |
| text-encoder-only | any | llm_adapter rename only, remap is a no-op |
