### PR TITLE
Load bitsandbytes NF4 / FP4 checkpoints without bitsandbytes

### DIFF
--- a/backend/loader.py
+++ b/backend/loader.py
@@ -29,6 +29,7 @@ from backend.diffusion_engine.wan import Wan
 from backend.diffusion_engine.zimage import ZImage
 from backend.logging import setup_logger
 from backend.operations import using_forge_operations
+from backend.operations_nf4 import with_4bit_shapes
 from backend.state_dict import (
     convert_quantization,
     detect_quantization,
@@ -443,6 +444,9 @@ def load_huggingface_component(guess, component_name, lib_name, cls_name, repo_p
                 logger.info(f"Using Detected Model Data Type: {_log}")
                 if state_dict_dtype == "gguf":
                     beautiful_print_gguf_state_dict_statics(state_dict)
+                elif state_dict_dtype in ["nf4", "fp4"] and not backend.args.dynamic_args.online_lora:
+                    logger.warning(f"{state_dict_dtype} requires fp16 LoRA ; overriding option")
+                    backend.args.dynamic_args.online_lora = True
             else:
                 if override_dtype is not None:
                     storage_dtype = override_dtype
@@ -801,7 +805,7 @@ def _load_unet(path: os.PathLike):
     sd, metadata = load_torch_file(path, return_metadata=True)
     sd, metadata = convert_quantization(sd, metadata)
     sd = preprocess_state_dict(sd)
-    guess = huggingface_guess.guess(sd)
+    guess = huggingface_guess.guess(with_4bit_shapes(sd))
 
     return sd, metadata, guess
 
@@ -814,7 +818,7 @@ def _load_diffuser(path: os.PathLike):
     if (sd := convert_diffusers_mmdit(sd, "")) is None:
         raise ModuleNotFoundError("Failed to recognize model...")
     sd = preprocess_state_dict(sd)
-    guess = huggingface_guess.guess(sd)
+    guess = huggingface_guess.guess(with_4bit_shapes(sd))
 
     return sd, metadata, guess
 

--- a/backend/operations.py
+++ b/backend/operations.py
@@ -391,6 +391,45 @@ class ForgeOperations:
 
 
 from backend.operations_gguf import dequantize_tensor
+from backend.operations_nf4 import dequantize_nf4, load_nf4_parameter
+
+
+class ForgeOperationsNF4(ForgeOperations):
+    class Linear(torch.nn.Module, ForgeWeights):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+            self.dummy = {"device": current_device, "dtype": current_dtype}
+            self.weight = None
+            self.bias = None
+
+        def _load_from_state_dict(self, state_dict, prefix, *args, **kwargs):
+            if hasattr(self, "dummy"):
+                computation_dtype = self.dummy["dtype"]
+
+                if (weight := load_nf4_parameter(state_dict, prefix + "weight", self.dummy["device"], computation_dtype)) is not None:
+                    self.weight = weight
+                elif prefix + "weight" in state_dict:
+                    self.weight = utils.tensor2parameter(state_dict[prefix + "weight"].to(device=self.dummy["device"], dtype=computation_dtype))
+                if prefix + "bias" in state_dict:
+                    self.bias = utils.tensor2parameter(state_dict[prefix + "bias"].to(device=self.dummy["device"], dtype=computation_dtype))
+
+                del self.dummy
+            else:
+                if prefix + "weight" in state_dict:
+                    self.weight = state_dict[prefix + "weight"]
+                if prefix + "bias" in state_dict:
+                    self.bias = state_dict[prefix + "bias"]
+
+        def _apply(self, fn, recurse=True):
+            for k, p in self.named_parameters(recurse=False, remove_duplicate=True):
+                setattr(self, k, utils.tensor2parameter(fn(p)))
+            return self
+
+        def forward(self, x):
+            # cast the bias per call instead of replacing it: the memory manager may have pinned it
+            weight, bias, signal = weights_manual_cast(self, x, weight_fn=dequantize_nf4)
+            with main_stream_worker(weight, bias, signal):
+                return torch.nn.functional.linear(x, weight, bias)
 
 
 class ForgeOperationsGGUF(ForgeOperations):
@@ -664,6 +703,8 @@ def using_forge_operations(operations=None, device=None, dtype=None, manual_cast
     if operations is None:
         if extra_dtype in ["gguf"]:
             operations = ForgeOperationsGGUF
+        elif extra_dtype in ["nf4", "fp4"]:
+            operations = ForgeOperationsNF4
         elif extra_dtype in ["vae"] and args.tiled_conv2d:
             memory_management.logger.info(f"Using TiledOperations ({args.tiled_conv2d}) for VAE")
             operations = TiledOperations

--- a/backend/operations_nf4.py
+++ b/backend/operations_nf4.py
@@ -1,0 +1,139 @@
+import json
+
+import torch
+
+# bitsandbytes 4-bit layout (`QuantState.as_dict(packed=True)`): `<key>` uint8 [numel/2, 1] two codes per byte (high nibble first),
+# `<key>.absmax` float32 per block, `<key>.quant_map` float32 [16] codebook, `<key>.quant_state.bitsandbytes__nf4` JSON
+# with blocksize / shape (+ nested_* when the absmax is itself 8-bit quantized)
+
+QUANT_STATE_KEYS = ("quant_state.bitsandbytes__nf4", "quant_state.bitsandbytes__fp4")
+
+
+class ParameterNF4(torch.nn.Parameter):
+    # one uint8 buffer: packed weights followed by the absmax bytes, so that moving and pinning see a single tensor (like ParameterGGUF)
+
+    def __init__(self, torch_tensor, *, real_shape=None, blocksize=64, code=None, packed_bytes=0, nested=None, no_init=False):
+        super().__init__()
+        if no_init:
+            return
+
+        self.real_shape: torch.Size = torch.Size(real_shape)
+        self.blocksize: int = blocksize
+        self.code: torch.Tensor = code  # float32 [16]
+        self.packed_bytes: int = packed_bytes
+        self.nested: dict | None = nested  # {"code": float32 [256], "blocksize": int, "offset": float, "absmax_bytes": int}
+        self.computation_dtype = torch.float16
+
+    def __new__(cls, torch_tensor, *, real_shape=None, blocksize=64, code=None, packed_bytes=0, nested=None, no_init=False):
+        return super().__new__(cls, torch_tensor, requires_grad=False)
+
+    @property
+    def shape(self):
+        return self.real_shape
+
+    def copy_with_data(self, data):
+        new = ParameterNF4(data, no_init=True)
+        new.real_shape = self.real_shape
+        new.blocksize = self.blocksize
+        new.code = self.code.to(data.device)
+        new.packed_bytes = self.packed_bytes
+        new.nested = None if self.nested is None else {**self.nested, "code": self.nested["code"].to(data.device)}
+        new.computation_dtype = self.computation_dtype
+        return new
+
+    def to(self, *args, **kwargs):
+        device, _, non_blocking, _ = torch._C._nn._parse_to(*args, **{k: v for k, v in kwargs.items() if k != "copy"})
+        return self.copy_with_data(self.data.to(device=device, non_blocking=non_blocking, copy=kwargs.get("copy", False)))
+
+    def pin_memory(self, device=None):
+        return self.copy_with_data(torch.Tensor.pin_memory(self, device=device))
+
+
+def load_nf4_parameter(state_dict: dict, key: str, device: torch.device, computation_dtype: torch.dtype) -> ParameterNF4 | None:
+    qs_key = next((f"{key}.{k}" for k in QUANT_STATE_KEYS if f"{key}.{k}" in state_dict), None)
+    if qs_key is None:
+        return None
+
+    meta = json.loads(bytes(state_dict[qs_key].tolist()).decode())
+    packed = state_dict[key].reshape(-1)
+    absmax = state_dict[f"{key}.absmax"]
+    nested = None
+
+    def aligned(*parts):  # float32 sections must start at a multiple of 4 bytes
+        out = []
+        for part in parts:
+            if out and (pad := -sum(x.numel() for x in out) % 4):
+                out.append(torch.zeros(pad, dtype=torch.uint8, device=part.device))
+            out.append(part.reshape(-1).view(torch.uint8))
+        return torch.cat(out)
+
+    if "nested_absmax" in meta or f"{key}.nested_absmax" in state_dict:
+        nested = {
+            "code": state_dict[f"{key}.nested_quant_map"].to(torch.float32),
+            "blocksize": int(meta["nested_blocksize"]),
+            "offset": float(meta["nested_offset"]),
+            "absmax_bytes": absmax.numel(),
+        }
+        buffer = aligned(packed, absmax, state_dict[f"{key}.nested_absmax"].to(torch.float32))
+    else:
+        buffer = aligned(packed, absmax.to(torch.float32))
+
+    param = ParameterNF4(
+        buffer.to(device),
+        real_shape=meta["shape"],
+        blocksize=int(meta["blocksize"]),
+        code=state_dict[f"{key}.quant_map"].to(device=device, dtype=torch.float32),
+        packed_bytes=packed.numel(),
+        nested=nested,
+    )
+    param.computation_dtype = computation_dtype
+    return param
+
+
+def with_4bit_shapes(state_dict: dict) -> dict:
+    # for architecture detection: replace each packed [numel/2, 1] weight by a meta tensor of its real shape
+    keys = [k for k in state_dict if any(k.endswith(q) for q in QUANT_STATE_KEYS)]
+    if not keys:
+        return state_dict
+
+    sd = dict(state_dict)
+    for k in keys:
+        meta = json.loads(bytes(state_dict[k].tolist()).decode())
+        sd[k.split(".weight.")[0] + ".weight"] = torch.empty(meta["shape"], dtype=torch.bfloat16, device="meta")
+    return sd
+
+
+def _blockwise(values: torch.Tensor, absmax: torch.Tensor, blocksize: int) -> torch.Tensor:
+    full = (values.numel() // blocksize) * blocksize
+    out = values[:full].view(-1, blocksize) * absmax[: full // blocksize].view(-1, 1)
+    if full < values.numel():
+        out = torch.cat([out.reshape(-1), values[full:] * absmax[full // blocksize]])
+    return out.reshape(-1)
+
+
+def dequantize_nf4(weight: torch.Tensor) -> torch.Tensor:
+    if not isinstance(weight, ParameterNF4):
+        return weight
+
+    data = weight.data
+    dtype = weight.computation_dtype
+    packed = data[: weight.packed_bytes]
+
+    align = lambda n: (n + 3) // 4 * 4
+    if weight.nested is None:
+        absmax = data[align(weight.packed_bytes) :].view(torch.float32)
+    else:
+        start = align(weight.packed_bytes)
+        n = weight.nested["absmax_bytes"]
+        codes = data[start : start + n]
+        absmax2 = data[align(start + n) :].view(torch.float32)
+        absmax = _blockwise(weight.nested["code"][codes.long()], absmax2, weight.nested["blocksize"]) + weight.nested["offset"]
+
+    # bf16 has too few mantissa bits for the blockwise multiply (4e-3 relative error vs 2e-4 in fp16); use fp32 like bitsandbytes
+    math_dtype = torch.float32 if dtype == torch.bfloat16 else dtype
+    code = weight.code.to(math_dtype)
+    byte = torch.arange(256, device=data.device)
+    table = torch.stack([code[byte >> 4], code[byte & 0x0F]], dim=1)
+    values = table.index_select(0, packed.int()).view(-1)[: weight.real_shape.numel()]
+
+    return _blockwise(values, absmax.to(math_dtype), weight.blocksize).reshape(weight.real_shape).to(dtype)

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -1,6 +1,7 @@
 import json
 import math
 import os.path
+import struct
 
 import safetensors
 import torch
@@ -58,6 +59,48 @@ def read_arbitrary_config(directory: os.PathLike) -> dict:
     return config_data
 
 
+SAFETENSORS_DTYPES = {
+    "F64": torch.float64,
+    "F32": torch.float32,
+    "F16": torch.float16,
+    "BF16": torch.bfloat16,
+    "F8_E4M3": torch.float8_e4m3fn,
+    "F8_E5M2": torch.float8_e5m2,
+    "I64": torch.int64,
+    "I32": torch.int32,
+    "I16": torch.int16,
+    "I8": torch.int8,
+    "U8": torch.uint8,
+    "BOOL": torch.bool,
+}
+
+
+def read_safetensors(ckpt: str, device: torch.device) -> tuple[dict[str, torch.Tensor], dict | None]:
+    with open(ckpt, "rb") as f:
+        n = struct.unpack("<Q", f.read(8))[0]
+        header: dict = json.loads(f.read(n))
+        metadata = header.pop("__metadata__", None)
+
+        sd = {}
+        for k, h in sorted(header.items(), key=lambda kv: kv[1]["data_offsets"][0]):
+            start, end = h["data_offsets"]
+            dtype = SAFETENSORS_DTYPES[h["dtype"]]
+            if end > start:
+                f.seek(8 + n + start)
+                tensor = torch.frombuffer(bytearray(f.read(end - start)), dtype=torch.uint8).view(dtype).reshape(h["shape"])
+            else:
+                tensor = torch.empty(h["shape"], dtype=dtype)
+            sd[k] = tensor if device.type == "cpu" else tensor.to(device)
+
+    return sd, metadata
+
+
+def is_4bit_safetensors(ckpt: str) -> bool:
+    with open(ckpt, "rb") as f:
+        n = struct.unpack("<Q", f.read(8))[0]
+        return b"bitsandbytes__nf4" in (head := f.read(n)) or b"bitsandbytes__fp4" in head
+
+
 def load_torch_file(ckpt: str, *, safe_load=True, device=None, return_metadata=False) -> dict[str, torch.Tensor]:
     """https://github.com/Comfy-Org/ComfyUI/blob/v0.10.0/comfy/utils.py#L59"""
 
@@ -66,15 +109,22 @@ def load_torch_file(ckpt: str, *, safe_load=True, device=None, return_metadata=F
 
     if ckpt.lower().endswith((".safetensors", ".sft")):
         try:
-            with safetensors.safe_open(ckpt, framework="pt", device=device.type) as f:
-                sd = {}
-                for k in f.keys():
-                    tensor = f.get_tensor(k)
-                    if DISABLE_MMAP:
-                        tensor = tensor.to(device=device, copy=True)
-                    sd[k] = tensor
-                if return_metadata:
-                    metadata = f.metadata()
+            if is_4bit_safetensors(ckpt):
+                # the packed weights get repacked into new buffers anyway; the copy-on-write mapping
+                # of a 12 GB file would only double the commit charge, and the offload fails on Windows
+                sd, metadata = read_safetensors(ckpt, device)
+                if not return_metadata:
+                    metadata = None
+            else:
+                with safetensors.safe_open(ckpt, framework="pt", device=device.type) as f:
+                    sd = {}
+                    for k in f.keys():
+                        tensor = f.get_tensor(k)
+                        if DISABLE_MMAP:
+                            tensor = tensor.to(device=device, copy=True)
+                        sd[k] = tensor
+                    if return_metadata:
+                        metadata = f.metadata()
         except Exception:
             raise ValueError(f'\nModel "{ckpt}" is corrupt or invalid...\nPlease download the model again\n') from None
 
@@ -178,6 +228,11 @@ def calculate_parameters(sd: dict[str, torch.Tensor], prefix: str = "") -> int:
 def weight_dtype(sd: dict[str, torch.Tensor], prefix: str = "") -> torch.dtype | str:
     if any(hasattr(v, "gguf_cls") for v in sd.values()):
         return "gguf"
+    for k in sd:
+        if "bitsandbytes__nf4" in k:
+            return "nf4"
+        if "bitsandbytes__fp4" in k:
+            return "fp4"
 
     dtypes: dict[torch.dtype, int] = {}
     for k in sd.keys():


### PR DESCRIPTION
Restores loading of the `bnb-nf4` / `fp4` checkpoints (`flux1-dev-bnb-nf4-v2` and friends) with no dependency on `bitsandbytes`: the packed 4-bit weights are kept as one uint8 `ParameterNF4` (packed + absmax, like `ParameterGGUF`) and dequantized in `weights_manual_cast`, so offloading, `--cuda-stream` and pinning work as for GGUF. Nested (double) quantization is supported.

No behaviour change for other checkpoints: the path only triggers on files containing `quant_state.bitsandbytes__nf4/fp4` keys. Such checkpoints force online LoRA (fp16 LoRA), like GGUF. 4-bit files are read without mmap, the tensors are repacked into new buffers anyway.

Tested on a GTX 1070 8 GB / Windows 11, torch 2.10.0+cu126:

| Checkpoint | Result |
|---|---|
| flux1-dev-bnb-nf4-v2 (bundle with T5/CLIP/VAE) | txt2img, batch 2, LoRA, img2img, hires fix, switch to GGUF and back; 512x768 8 steps 8.2–9.0 s/it vs 8.0–9.0 s/it for flux1-dev-Q4_0.gguf |
| FluxFusionV2_NF4 (unet only), FluxFusionDS nf4 (nested, bundle) | OK |
| Wan2.1-T2V-1.3B-nf4 (nested, diffusers-made) | all 306 layers relerr 0.09–0.13 vs fp16, image corr 0.98 |
| diffusers/t5-nf4 as text encoder | all 144 layers relerr ≤ 0.125, generation OK |
| Flux nf4 vs fp8 of the same model | cosine 0.991–1.000 |

Not tested: FP4 (no real checkpoints exist, synthetic check only), Linux / AMD, bf16 GPUs (fp32 multiply path checked synthetically only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
