### PR TITLE
Build models on the meta device when the state dict fits

### DIFF
--- a/backend/loader.py
+++ b/backend/loader.py
@@ -51,13 +51,6 @@ setup_logger(logger)
 HF = os.path.join(os.path.dirname(__file__), "huggingface")
 
 
-def build_device(storage_dtype, state_dict_dtype, quant_config=None) -> torch.device:
-    # when the file already holds what the module wants, load_state_dict adopts its tensors: do not allocate weights that get overwritten
-    if quant_config is None and storage_dtype == state_dict_dtype:
-        return torch.device("meta")
-    return memory_management.cpu
-
-
 def load_huggingface_component(guess, component_name, lib_name, cls_name, repo_path, state_dict):
     config_path = os.path.join(repo_path, component_name)
 
@@ -73,6 +66,8 @@ def load_huggingface_component(guess, component_name, lib_name, cls_name, repo_p
             comp = cls.from_pretrained(os.path.join(repo_path, component_name))
             comp._eventual_warn_about_too_long_sequence = lambda *args, **kwargs: None
             return comp
+
+        state_dict_dtype = utils.weight_dtype(state_dict)
 
         # region VAE
 
@@ -147,20 +142,16 @@ def load_huggingface_component(guess, component_name, lib_name, cls_name, repo_p
 
         if component_name.startswith("text_encoder") and cls_name in ["CLIPTextModel", "CLIPTextModelWithProjection"]:
             assert isinstance(state_dict, dict) and len(state_dict) > 16, "You do not have CLIP state dict!"
+
             from transformers import CLIPTextConfig, CLIPTextModel
 
             from backend.nn.clip import IntegratedCLIP
 
             config = CLIPTextConfig.from_pretrained(config_path)
 
-            to_args = dict(device=memory_management.cpu, dtype=memory_management.text_encoder_dtype())
-            device = build_device(to_args["dtype"], utils.weight_dtype(state_dict))
-
             with no_init_weights():
-                with using_forge_operations(device=device, dtype=to_args["dtype"], manual_cast_enabled=True):
+                with using_forge_operations(device=memory_management.cpu, dtype=memory_management.text_encoder_dtype(), manual_cast_enabled=True, sd_dtype=state_dict_dtype):
                     model = IntegratedCLIP(CLIPTextModel, config, add_text_projection=True)
-                    if device.type != "meta":
-                        model = model.to(**to_args)
 
             load_state_dict(model, state_dict, ignore_errors=["transformer.text_projection.weight", "transformer.text_model.embeddings.position_ids", "logit_scale"], log_name=cls_name)
             return model
@@ -193,7 +184,7 @@ def load_huggingface_component(guess, component_name, lib_name, cls_name, repo_p
                         model = Qwen25_7BVLI(config)
             else:
                 with no_init_weights():
-                    with using_forge_operations(device=build_device(storage_dtype, state_dict_dtype, quant_config), dtype=storage_dtype, manual_cast_enabled=True, extra_dtype=quant_config):
+                    with using_forge_operations(device=memory_management.cpu, dtype=storage_dtype, manual_cast_enabled=True, sd_dtype=state_dict_dtype, extra_dtype=quant_config):
                         model = Qwen25_7BVLI(config)
 
             load_state_dict(model, state_dict, log_name=cls_name, ignore_start="lm_head.")
@@ -227,7 +218,7 @@ def load_huggingface_component(guess, component_name, lib_name, cls_name, repo_p
                         model = Gemma2_2B(config)
             else:
                 with no_init_weights():
-                    with using_forge_operations(device=build_device(storage_dtype, state_dict_dtype, quant_config), dtype=storage_dtype, manual_cast_enabled=True, extra_dtype=quant_config):
+                    with using_forge_operations(device=memory_management.cpu, dtype=storage_dtype, manual_cast_enabled=True, sd_dtype=state_dict_dtype, extra_dtype=quant_config):
                         model = Gemma2_2B(config)
 
             load_state_dict(model, state_dict, log_name=cls_name, ignore_start="lm_head.")
@@ -261,7 +252,7 @@ def load_huggingface_component(guess, component_name, lib_name, cls_name, repo_p
                         model = Ministral3_3B(config)
             else:
                 with no_init_weights():
-                    with using_forge_operations(device=build_device(storage_dtype, state_dict_dtype, quant_config), dtype=storage_dtype, manual_cast_enabled=True, extra_dtype=quant_config):
+                    with using_forge_operations(device=memory_management.cpu, dtype=storage_dtype, manual_cast_enabled=True, sd_dtype=state_dict_dtype, extra_dtype=quant_config):
                         model = Ministral3_3B(config)
 
             load_state_dict(model, state_dict, log_name=cls_name)
@@ -302,7 +293,7 @@ def load_huggingface_component(guess, component_name, lib_name, cls_name, repo_p
                         model = QTE(config)
             else:
                 with no_init_weights():
-                    with using_forge_operations(device=build_device(storage_dtype, state_dict_dtype, quant_config), dtype=storage_dtype, manual_cast_enabled=True, extra_dtype=quant_config):
+                    with using_forge_operations(device=memory_management.cpu, dtype=storage_dtype, manual_cast_enabled=True, sd_dtype=state_dict_dtype, extra_dtype=quant_config):
                         model = QTE(config)
 
             if cls_name == "Qwen3VLModel":
@@ -356,7 +347,7 @@ def load_huggingface_component(guess, component_name, lib_name, cls_name, repo_p
                         model = IntegratedT5(config)
             else:
                 with no_init_weights():
-                    with using_forge_operations(device=build_device(storage_dtype, state_dict_dtype, quant_config), dtype=storage_dtype, manual_cast_enabled=True, extra_dtype=quant_config):
+                    with using_forge_operations(device=memory_management.cpu, dtype=storage_dtype, manual_cast_enabled=True, sd_dtype=state_dict_dtype, extra_dtype=quant_config):
                         model = IntegratedT5(config)
 
             load_state_dict(model, state_dict, log_name=cls_name, ignore_errors=["transformer.encoder.embed_tokens.weight", "logit_scale"])
@@ -436,7 +427,6 @@ def load_huggingface_component(guess, component_name, lib_name, cls_name, repo_p
 
             unet_config = guess.unet_config.copy()
             state_dict_parameters = utils.calculate_parameters(state_dict)
-            state_dict_dtype = utils.weight_dtype(state_dict)
             quant_config = detect_quantization(state_dict, is_unet=True)
 
             override_dtype = backend.args.dynamic_args.forge_unet_storage_dtype
@@ -488,15 +478,9 @@ def load_huggingface_component(guess, component_name, lib_name, cls_name, repo_p
                 else:
                     extra_dtype = None
 
-                device = memory_management.cpu
-                if memory_management.is_device_cpu(initial_device) and not guess.nunchaku:
-                    device = build_device(storage_dtype, state_dict_dtype, quant_config)
-
                 with no_init_weights():
-                    with using_forge_operations(device=device, dtype=storage_dtype, manual_cast_enabled=need_manual_cast, extra_dtype=extra_dtype):
+                    with using_forge_operations(**to_args, manual_cast_enabled=need_manual_cast, sd_dtype=state_dict_dtype, extra_dtype=extra_dtype):
                         model = model_loader(unet_config)
-                        if device.type != "meta":
-                            model = model.to(**to_args)
 
             model = pre_func(model)
             load_state_dict(model, state_dict)

--- a/backend/loader.py
+++ b/backend/loader.py
@@ -51,6 +51,13 @@ setup_logger(logger)
 HF = os.path.join(os.path.dirname(__file__), "huggingface")
 
 
+def build_device(storage_dtype, state_dict_dtype, quant_config=None) -> torch.device:
+    # when the file already holds what the module wants, load_state_dict adopts its tensors: do not allocate weights that get overwritten
+    if quant_config is None and storage_dtype == state_dict_dtype:
+        return torch.device("meta")
+    return memory_management.cpu
+
+
 def load_huggingface_component(guess, component_name, lib_name, cls_name, repo_path, state_dict):
     config_path = os.path.join(repo_path, component_name)
 
@@ -147,10 +154,13 @@ def load_huggingface_component(guess, component_name, lib_name, cls_name, repo_p
             config = CLIPTextConfig.from_pretrained(config_path)
 
             to_args = dict(device=memory_management.cpu, dtype=memory_management.text_encoder_dtype())
+            device = build_device(to_args["dtype"], utils.weight_dtype(state_dict))
 
             with no_init_weights():
-                with using_forge_operations(**to_args, manual_cast_enabled=True):
-                    model = IntegratedCLIP(CLIPTextModel, config, add_text_projection=True).to(**to_args)
+                with using_forge_operations(device=device, dtype=to_args["dtype"], manual_cast_enabled=True):
+                    model = IntegratedCLIP(CLIPTextModel, config, add_text_projection=True)
+                    if device.type != "meta":
+                        model = model.to(**to_args)
 
             load_state_dict(model, state_dict, ignore_errors=["transformer.text_projection.weight", "transformer.text_model.embeddings.position_ids", "logit_scale"], log_name=cls_name)
             return model
@@ -183,7 +193,7 @@ def load_huggingface_component(guess, component_name, lib_name, cls_name, repo_p
                         model = Qwen25_7BVLI(config)
             else:
                 with no_init_weights():
-                    with using_forge_operations(device=memory_management.cpu, dtype=storage_dtype, manual_cast_enabled=True, extra_dtype=quant_config):
+                    with using_forge_operations(device=build_device(storage_dtype, state_dict_dtype, quant_config), dtype=storage_dtype, manual_cast_enabled=True, extra_dtype=quant_config):
                         model = Qwen25_7BVLI(config)
 
             load_state_dict(model, state_dict, log_name=cls_name, ignore_start="lm_head.")
@@ -217,7 +227,7 @@ def load_huggingface_component(guess, component_name, lib_name, cls_name, repo_p
                         model = Gemma2_2B(config)
             else:
                 with no_init_weights():
-                    with using_forge_operations(device=memory_management.cpu, dtype=storage_dtype, manual_cast_enabled=True, extra_dtype=quant_config):
+                    with using_forge_operations(device=build_device(storage_dtype, state_dict_dtype, quant_config), dtype=storage_dtype, manual_cast_enabled=True, extra_dtype=quant_config):
                         model = Gemma2_2B(config)
 
             load_state_dict(model, state_dict, log_name=cls_name, ignore_start="lm_head.")
@@ -251,7 +261,7 @@ def load_huggingface_component(guess, component_name, lib_name, cls_name, repo_p
                         model = Ministral3_3B(config)
             else:
                 with no_init_weights():
-                    with using_forge_operations(device=memory_management.cpu, dtype=storage_dtype, manual_cast_enabled=True, extra_dtype=quant_config):
+                    with using_forge_operations(device=build_device(storage_dtype, state_dict_dtype, quant_config), dtype=storage_dtype, manual_cast_enabled=True, extra_dtype=quant_config):
                         model = Ministral3_3B(config)
 
             load_state_dict(model, state_dict, log_name=cls_name)
@@ -292,7 +302,7 @@ def load_huggingface_component(guess, component_name, lib_name, cls_name, repo_p
                         model = QTE(config)
             else:
                 with no_init_weights():
-                    with using_forge_operations(device=memory_management.cpu, dtype=storage_dtype, manual_cast_enabled=True, extra_dtype=quant_config):
+                    with using_forge_operations(device=build_device(storage_dtype, state_dict_dtype, quant_config), dtype=storage_dtype, manual_cast_enabled=True, extra_dtype=quant_config):
                         model = QTE(config)
 
             if cls_name == "Qwen3VLModel":
@@ -346,7 +356,7 @@ def load_huggingface_component(guess, component_name, lib_name, cls_name, repo_p
                         model = IntegratedT5(config)
             else:
                 with no_init_weights():
-                    with using_forge_operations(device=memory_management.cpu, dtype=storage_dtype, manual_cast_enabled=True, extra_dtype=quant_config):
+                    with using_forge_operations(device=build_device(storage_dtype, state_dict_dtype, quant_config), dtype=storage_dtype, manual_cast_enabled=True, extra_dtype=quant_config):
                         model = IntegratedT5(config)
 
             load_state_dict(model, state_dict, log_name=cls_name, ignore_errors=["transformer.encoder.embed_tokens.weight", "logit_scale"])
@@ -478,9 +488,15 @@ def load_huggingface_component(guess, component_name, lib_name, cls_name, repo_p
                 else:
                     extra_dtype = None
 
+                device = memory_management.cpu
+                if memory_management.is_device_cpu(initial_device) and not guess.nunchaku:
+                    device = build_device(storage_dtype, state_dict_dtype, quant_config)
+
                 with no_init_weights():
-                    with using_forge_operations(**to_args, manual_cast_enabled=need_manual_cast, extra_dtype=extra_dtype):
-                        model = model_loader(unet_config).to(**to_args)
+                    with using_forge_operations(device=device, dtype=storage_dtype, manual_cast_enabled=need_manual_cast, extra_dtype=extra_dtype):
+                        model = model_loader(unet_config)
+                        if device.type != "meta":
+                            model = model.to(**to_args)
 
             model = pre_func(model)
             load_state_dict(model, state_dict)

--- a/backend/operations.py
+++ b/backend/operations.py
@@ -635,7 +635,19 @@ class TiledOperations(ForgeOperations):
 
 
 @contextlib.contextmanager
-def using_forge_operations(operations=None, device=None, dtype=None, manual_cast_enabled=False, extra_dtype=None):
+def using_forge_operations(
+    *,
+    operations: "ForgeOperations" = None,
+    device: torch.device = None,
+    dtype: torch.dtype = None,
+    manual_cast_enabled: bool = False,
+    sd_dtype: torch.dtype = None,
+    extra_dtype: torch.dtype = None,
+):
+
+    if extra_dtype is None and dtype == sd_dtype:
+        device = torch.device("meta")
+
     global current_device, current_dtype, current_manual_cast_enabled
 
     current_device, current_dtype, current_manual_cast_enabled = device, dtype, manual_cast_enabled

--- a/backend/state_dict.py
+++ b/backend/state_dict.py
@@ -3,25 +3,25 @@ import json
 import torch
 
 
-def load_state_dict(model, sd, ignore_errors=[], log_name=None, ignore_start=None):
-    # a model built on the meta device owns no storage: adopt the tensors instead of copying into it
-    assign = any(p.is_meta for p in model.parameters())
-    if assign:
-        for name, param in list(model.named_parameters()) + list(model.named_buffers()):
-            entry = sd.get(name)
-            if entry is not None and entry.dtype != param.dtype:
-                sd[name] = entry.to(param.dtype)  # the module picked that dtype on purpose, e.g. fp32 embeddings
+def load_state_dict(model: torch.nn.Module, sd: dict[str, torch.Tensor], ignore_errors: list[str] = [], log_name: str = None, ignore_start: str = None):
+    is_meta = any(p.is_meta for p in model.parameters())
 
-    missing, unexpected = model.load_state_dict(sd, strict=False, assign=assign)
+    if is_meta:
+        for name, param in [*model.named_parameters(), *model.named_buffers()]:
+            if (entry := sd.get(name, None)) is not None and entry.dtype != param.dtype:
+                sd[name] = entry.to(param.dtype)
 
-    if assign:
-        for module in model.modules():  # whatever the file did not carry has to become real storage
+    missing, unexpected = model.load_state_dict(sd, strict=False, assign=is_meta)
+
+    if is_meta:
+        for module in model.modules():
             for name, param in module._parameters.items():
                 if param is not None and param.is_meta:
-                    module._parameters[name] = torch.nn.Parameter(torch.zeros(param.shape, dtype=param.dtype), requires_grad=param.requires_grad)
+                    module._parameters[name] = torch.nn.Parameter(torch.zeros(param.shape, dtype=param.dtype), requires_grad=False)
             for name, buffer in module._buffers.items():
                 if buffer is not None and buffer.is_meta:
                     module._buffers[name] = torch.zeros(buffer.shape, dtype=buffer.dtype)
+
     missing = [x for x in missing if x not in ignore_errors]
     unexpected = [x for x in unexpected if x not in ignore_errors]
 

--- a/backend/state_dict.py
+++ b/backend/state_dict.py
@@ -4,7 +4,24 @@ import torch
 
 
 def load_state_dict(model, sd, ignore_errors=[], log_name=None, ignore_start=None):
-    missing, unexpected = model.load_state_dict(sd, strict=False)
+    # a model built on the meta device owns no storage: adopt the tensors instead of copying into it
+    assign = any(p.is_meta for p in model.parameters())
+    if assign:
+        for name, param in list(model.named_parameters()) + list(model.named_buffers()):
+            entry = sd.get(name)
+            if entry is not None and entry.dtype != param.dtype:
+                sd[name] = entry.to(param.dtype)  # the module picked that dtype on purpose, e.g. fp32 embeddings
+
+    missing, unexpected = model.load_state_dict(sd, strict=False, assign=assign)
+
+    if assign:
+        for module in model.modules():  # whatever the file did not carry has to become real storage
+            for name, param in module._parameters.items():
+                if param is not None and param.is_meta:
+                    module._parameters[name] = torch.nn.Parameter(torch.zeros(param.shape, dtype=param.dtype), requires_grad=param.requires_grad)
+            for name, buffer in module._buffers.items():
+                if buffer is not None and buffer.is_meta:
+                    module._buffers[name] = torch.zeros(buffer.shape, dtype=buffer.dtype)
     missing = [x for x in missing if x not in ignore_errors]
     unexpected = [x for x in unexpected if x not in ignore_errors]
 


### PR DESCRIPTION
Every component allocates its weights and `load_state_dict` overwrites them right after. On Windows that is paid for twice: the CPU allocator rounds the large blocks up and does not return them, so building an empty T5XXL costs 8.0 GB of commit for 4.8 GB of tensors.

This builds the module on the meta device whenever the file already carries the dtype the module asked for, and lets `load_state_dict` adopt those tensors. Entries the module wants in a different dtype (the fp32 token embedding) are cast in the state dict first, and anything the file does not carry is materialised, so no meta tensor survives the load. The UNet only takes the path when it would have been built on the CPU anyway; when it loads straight to VRAM there is nothing to save and the old path is kept.

Peak process commit during the load, GTX 1070 / 64 GB / Windows 11, read with `GetProcessMemoryInfo`:

| checkpoint | peak before | peak after | load time |
| --- | --- | --- | --- |
| RealVisXL 4.0 (fp16, 6.5 GB) | 14.03 GB | 8.75 GB | 7.4 → 6.5 s |
| Flux.1-dev Q4_0 + fp8 T5XXL | 14.86 GB | 11.33 GB | 3.7 → 2.2 s |

SDXL is measured with `--disable-mmap`; through `safe_open` the copy-on-write mapping of the file peaks at 14.6 GB on its own and hides most of the saving. GGUF weights are unaffected either way, they never allocated anything.

Loading also gets faster, there is one copy of the weights less.

Tested on that hardware: RealVisXL 4.0 20 steps 512x768 and Flux.1-dev Q4_0 8 steps 512x512, same seed, both images byte-identical to the branch point, compared pixel for pixel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
