### PR TITLE
int8 GEMM for the Linear layers of Flux / Chroma / Z-Image: 2.7x on average

### DIFF
--- a/backend/args.py
+++ b/backend/args.py
@@ -99,6 +99,7 @@ parser.add_argument("--fast-fp8", action="store_true", help="torch._scaled_mm")
 parser.add_argument("--fast-fp16", action="store_true", help="torch.backends.cuda.matmul.allow_fp16_accumulation")
 parser.add_argument("--autotune", action="store_true", help="torch.backends.cudnn.benchmark")
 parser.add_argument("--int8-linear", action="store_true", help="torch._int_mm for the Linear layers of Flux / Chroma / Z-Image")
+parser.add_argument("--int8-cache", action="store_true", help="--int8-linear, with the int8 weights kept in models/int8 instead of quantised at every load")
 
 parser.add_argument("--mmap-torch-files", action="store_true", help="Use mmap when loading ckpt/pt files")
 parser.add_argument("--disable-mmap", action="store_true", help="Don't use mmap when loading safetensors")

--- a/backend/args.py
+++ b/backend/args.py
@@ -98,6 +98,7 @@ parser.add_argument("--expandable-segments", action="store_true", help="improve 
 parser.add_argument("--fast-fp8", action="store_true", help="torch._scaled_mm")
 parser.add_argument("--fast-fp16", action="store_true", help="torch.backends.cuda.matmul.allow_fp16_accumulation")
 parser.add_argument("--autotune", action="store_true", help="torch.backends.cudnn.benchmark")
+parser.add_argument("--int8-linear", action="store_true", help="torch._int_mm for the Linear layers of Flux / Chroma / Z-Image")
 
 parser.add_argument("--mmap-torch-files", action="store_true", help="Use mmap when loading ckpt/pt files")
 parser.add_argument("--disable-mmap", action="store_true", help="Don't use mmap when loading safetensors")

--- a/backend/loader.py
+++ b/backend/loader.py
@@ -484,6 +484,11 @@ def load_huggingface_component(guess, component_name, lib_name, cls_name, repo_p
 
             model = pre_func(model)
             load_state_dict(model, state_dict)
+
+            if backend.args.args.int8_linear and not guess.nunchaku:
+                from backend.operations_int8 import quantize_model
+
+                quantize_model(model)
             # model = post_func(model)
 
             if hasattr(model, "_internal_dict"):

--- a/backend/loader.py
+++ b/backend/loader.py
@@ -485,10 +485,10 @@ def load_huggingface_component(guess, component_name, lib_name, cls_name, repo_p
             model = pre_func(model)
             load_state_dict(model, state_dict)
 
-            if backend.args.args.int8_linear and not guess.nunchaku:
+            if (backend.args.args.int8_linear or backend.args.args.int8_cache) and not guess.nunchaku:
                 from backend.operations_int8 import quantize_model
 
-                quantize_model(model)
+                quantize_model(model, getattr(guess, "checkpoint_path", None) if backend.args.args.int8_cache else None)
             # model = post_func(model)
 
             if hasattr(model, "_internal_dict"):
@@ -889,6 +889,7 @@ def forge_loader(sd: os.PathLike, additional_state_dicts: list[os.PathLike] = No
     backend.args.dynamic_args.reset()
     backend.args.dynamic_args.kontext = "kontext" in str(sd).lower()
     backend.args.dynamic_args.edit = "qwen" in str(sd).lower() and "edit" in str(sd).lower()
+    estimated_config.checkpoint_path = str(sd)
     backend.args.dynamic_args.nunchaku = getattr(estimated_config, "nunchaku", False)
     backend.args.dynamic_args.klein = "klein" in repo_name
     backend.args.dynamic_args.wan = "Wan" in repo_name

--- a/backend/memory_management.py
+++ b/backend/memory_management.py
@@ -1477,7 +1477,7 @@ def sync_stream(device: torch.device, stream):
 
 
 PINNED_MEMORY = {}
-PINNING_ALLOWED_TYPES = "Parameter"
+PINNING_ALLOWED_TYPES = ("Parameter", "ParameterInt8")
 
 TOTAL_PINNED_MEMORY = 0
 MAX_PINNED_MEMORY = -1
@@ -1506,7 +1506,7 @@ def pin_memory(tensor):
     if MAX_PINNED_MEMORY <= 0:
         return False
 
-    if type(tensor).__name__ != PINNING_ALLOWED_TYPES:
+    if type(tensor).__name__ not in PINNING_ALLOWED_TYPES:
         return False
 
     if not is_device_cpu(tensor.device):

--- a/backend/operations.py
+++ b/backend/operations.py
@@ -220,6 +220,8 @@ class ForgeOperations:
             return None
 
         def forward(self, x):
+            if isinstance(self.weight, ParameterInt8):
+                return int8_forward(self, x)
             if self.parameters_manual_cast:
                 weight, bias, signal = weights_manual_cast(self, x)
                 with main_stream_worker(weight, bias, signal):
@@ -391,6 +393,7 @@ class ForgeOperations:
 
 
 from backend.operations_gguf import dequantize_tensor
+from backend.operations_int8 import ParameterInt8, forward as int8_forward
 
 
 class ForgeOperationsGGUF(ForgeOperations):
@@ -426,6 +429,8 @@ class ForgeOperationsGGUF(ForgeOperations):
             return self
 
         def forward(self, x):
+            if isinstance(self.weight, ParameterInt8):
+                return int8_forward(self, x)
             if self.bias is not None and self.bias.dtype != x.dtype:
                 self.bias = utils.tensor2parameter(dequantize_tensor(self.bias).to(x.dtype))
             if self.weight is not None and self.weight.dtype != x.dtype and getattr(self.weight, "gguf_cls", None) is None:

--- a/backend/operations_int8.py
+++ b/backend/operations_int8.py
@@ -4,7 +4,10 @@ times faster than fp16 on every GPU without fp8 support. Weights are quantised o
 channel; activations per token at every call; a LoRA is added as a low-rank side branch, not merged.
 """
 
+import json
 import logging
+import os
+import struct
 from functools import partial
 
 import torch
@@ -20,6 +23,7 @@ INT8_MODELS = ("IntegratedFluxTransformer2DModel", "IntegratedChromaTransformer2
 MIN_ROWS = 17  # torch._int_mm needs M > 16; a modulation GEMV is padded up to it
 BLOCK_BYTES = 128 * 1024**2  # budget for one row block's int32 + fp32 temporaries
 ARENA_BYTES = 512 * 1024**2  # the Windows allocator rounds ~50 MB blocks up by half; pack the weights instead
+CACHE_VERSION = "1"  # bump when the blob layout or the quantisation changes
 
 
 class ParameterInt8(torch.nn.Parameter):
@@ -94,7 +98,51 @@ def int_mm_works(device: torch.device) -> bool:
         return False
 
 
-def quantize_model(model: torch.nn.Module) -> int:
+class Arena:
+    """Blobs are packed into a few big buffers: the Windows allocator rounds ~50 MB blocks up by half"""
+
+    def __init__(self):
+        self.buffer, self.at = None, 0
+
+    def slice(self, size: int) -> torch.Tensor:
+        if self.buffer is None or self.at + size > self.buffer.numel():
+            self.buffer, self.at = torch.empty(max(size, ARENA_BYTES), dtype=torch.uint8), 0
+        out = self.buffer[self.at : self.at + size]
+        self.at += size
+        return out
+
+
+def dequantize_source(weight: torch.Tensor, device: torch.device) -> torch.Tensor:
+    if getattr(weight, "gguf_cls", None) is not None:
+        from backend.loader_gguf import dequantize
+
+        return dequantize(weight.to(device), torch.float16)
+    return weight.to(device=device, dtype=torch.float16)
+
+
+def linear_layers(model: torch.nn.Module) -> tuple[list, int]:
+    from backend.operations import ForgeOperations, ForgeOperationsGGUF
+
+    supported = (ForgeOperations.Linear, ForgeOperationsGGUF.Linear)  # the Linear classes whose forward we hook
+    todo, skipped = [], 0
+    for name, module in model.named_modules():
+        if not isinstance(module, supported) or module.weight is None or module.weight.ndim != 2:
+            continue
+        n, k = module.weight.shape
+        if n % 8 or k % 8:
+            skipped += 1
+            continue
+        todo.append((name, module, (n, k)))
+    return todo, skipped
+
+
+def install(module, weight: ParameterInt8):
+    module.weight = weight
+    module.convert_weight = convert_weight  # the patcher merges a LoRA through these
+    module.set_weight = partial(set_weight, module)
+
+
+def quantize_model(model: torch.nn.Module, source: str = None) -> int:
     name = type(model).__name__
     if name not in INT8_MODELS:
         logger.info(f"Not quantising {name}: its Linear layers are too small to gain from int8")
@@ -104,40 +152,93 @@ def quantize_model(model: torch.nn.Module) -> int:
     if not int_mm_works(device):
         return 0
 
-    from backend.loader_gguf import dequantize
-    from backend.operations import ForgeOperations, ForgeOperationsGGUF
+    todo, skipped = linear_layers(model)
 
-    supported = (ForgeOperations.Linear, ForgeOperationsGGUF.Linear)  # the Linear classes whose forward we hook
-    count, skipped, arena, at = 0, 0, None, 0
+    if source is not None and os.path.isfile(source):
+        try:
+            path = cache_path(source)
+            if not cache_is_valid(path, source, name, todo):
+                build_cache(path, source, name, todo, device)
+            load_cache(path, todo)
+            logger.info(f"Loaded {len(todo)} int8 Linear layers of {name} from {os.path.basename(path)} ({skipped} skipped)")
+            return len(todo)
+        except Exception as e:
+            logger.warning(f"int8 cache unavailable ({e}); quantising into RAM instead")
 
-    for module in model.modules():
-        if not isinstance(module, supported) or module.weight is None or module.weight.ndim != 2:
-            continue
-        n, k = module.weight.shape
-        if n % 8 or k % 8:
-            skipped += 1
-            continue
+    arena = Arena()
+    for _, module, (n, k) in todo:
+        weight = quantize(dequantize_source(module.weight, device), getattr(module.weight, "computation_dtype", torch.float16), out=arena.slice(blob_size(n, k)))
+        weight.arena = arena.buffer
+        install(module, weight)
 
-        source = module.weight
-        if getattr(source, "gguf_cls", None) is not None:
-            source = dequantize(source.to(device), torch.float16)
-        else:
-            source = source.to(device=device, dtype=torch.float16)
+    logger.info(f"Quantised {len(todo)} Linear layers of {name} to int8 ({skipped} skipped)")
+    return len(todo)
 
+
+# region disk cache: a safetensors file of blobs, written one weight at a time and read back into the arenas,
+# so neither building it nor using it ever holds both the source and the int8 model
+
+
+def cache_path(source: str) -> str:
+    stem = os.path.splitext(os.path.basename(source))[0]
+    return os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(source))), "int8", f"{stem}.int8.safetensors")
+
+
+def cache_tags(source: str, model_name: str) -> dict[str, str]:
+    st = os.stat(source)
+    return {"int8_version": CACHE_VERSION, "model": model_name, "source": os.path.basename(source), "source_size": str(st.st_size), "source_mtime": str(int(st.st_mtime))}
+
+
+def read_header(path: str) -> tuple[dict, int]:
+    with open(path, "rb") as f:
+        n = struct.unpack("<Q", f.read(8))[0]
+        return json.loads(f.read(n)), 8 + n
+
+
+def cache_is_valid(path: str, source: str, model_name: str, todo: list) -> bool:
+    if not os.path.isfile(path):
+        return False
+    header, _ = read_header(path)
+    meta = header.pop("__metadata__", {})
+    if any(meta.get(k) != v for k, v in cache_tags(source, model_name).items()):
+        return False
+    shapes = json.loads(meta.get("shapes", "{}"))
+    return all(shapes.get(name) == [n, k] and header.get(name, {}).get("shape") == [blob_size(n, k)] for name, _, (n, k) in todo)
+
+
+def build_cache(path: str, source: str, model_name: str, todo: list, device: torch.device):
+    header, at = {}, 0
+    for name, _, (n, k) in todo:
         size = blob_size(n, k)
-        if arena is None or at + size > arena.numel():
-            arena, at = torch.empty(max(size, ARENA_BYTES), dtype=torch.uint8), 0
-        weight = quantize(source, getattr(module.weight, "computation_dtype", torch.float16), out=arena[at : at + size])
-        weight.arena = arena
+        header[name] = {"dtype": "U8", "shape": [size], "data_offsets": [at, at + size]}
         at += size
+    header["__metadata__"] = dict(cache_tags(source, model_name), shapes=json.dumps({name: [n, k] for name, _, (n, k) in todo}))
+    head = json.dumps(header).encode("utf-8")
+    head += b" " * (-len(head) % 8)
 
-        module.weight = weight
-        module.convert_weight = convert_weight  # the patcher merges a LoRA through these
-        module.set_weight = partial(set_weight, module)
-        count += 1
+    logger.info(f"Building the int8 cache {os.path.basename(path)} ({at / 2**30:.1f} GB)")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "wb") as f:
+        f.write(struct.pack("<Q", len(head)))
+        f.write(head)
+        for _, module, _ in todo:
+            f.write(quantize(dequantize_source(module.weight, device)).data.numpy().tobytes())
+    os.replace(tmp, path)
 
-    logger.info(f"Quantised {count} Linear layers of {name} to int8 ({skipped} skipped)")
-    return count
+
+def load_cache(path: str, todo: list):
+    header, data = read_header(path)
+    arena = Arena()
+    with open(path, "rb") as f:
+        for name, module, (n, k) in todo:
+            start, end = header[name]["data_offsets"]
+            blob = arena.slice(end - start)
+            f.seek(data + start)
+            f.readinto(memoryview(blob.numpy()))  # a plain read: the peak is the model, not twice the file
+            weight = ParameterInt8(blob, real_shape=(n, k), computation_dtype=getattr(module.weight, "computation_dtype", torch.float16))
+            weight.arena = arena.buffer
+            install(module, weight)
 
 
 def convert_weight(weight: ParameterInt8, inplace=False) -> torch.Tensor:

--- a/backend/operations_int8.py
+++ b/backend/operations_int8.py
@@ -1,0 +1,247 @@
+"""
+int8 GEMM for the Linear layers of a DiT. `torch._int_mm` reaches the dp4a / IMMA hardware, which is several
+times faster than fp16 on every GPU without fp8 support. Weights are quantised once at load, per output
+channel; activations per token at every call; a LoRA is added as a low-rank side branch, not merged.
+"""
+
+import logging
+from functools import partial
+
+import torch
+
+from backend import memory_management
+from backend.logging import setup_logger
+
+logger = logging.getLogger("int8")
+setup_logger(logger)
+
+# models whose Linear GEMMs are wide enough for the quantise / rescale passes to pay for themselves
+INT8_MODELS = ("IntegratedFluxTransformer2DModel", "IntegratedChromaTransformer2DModel", "NextDiT")
+MIN_ROWS = 17  # torch._int_mm needs M > 16; a modulation GEMV is padded up to it
+BLOCK_BYTES = 128 * 1024**2  # budget for one row block's int32 + fp32 temporaries
+ARENA_BYTES = 512 * 1024**2  # the Windows allocator rounds ~50 MB blocks up by half; pack the weights instead
+
+
+class ParameterInt8(torch.nn.Parameter):
+    """One flat uint8 blob: the int8 weight transposed to [K, N], then the fp32 per-output-channel scale [N]"""
+
+    def __new__(cls, data, *, real_shape=None, computation_dtype=None, requires_grad=False):
+        return super().__new__(cls, data, requires_grad=False)
+
+    def __init__(self, data, *, real_shape=None, computation_dtype=None, requires_grad=False):
+        super().__init__()
+        if real_shape is not None:
+            self.real_shape = torch.Size(real_shape)
+            self.computation_dtype = computation_dtype or torch.float16
+            self.arena: torch.Tensor | None = None
+
+    @property
+    def shape(self):
+        return self.real_shape
+
+    def copy_with_data(self, data):
+        new = ParameterInt8(data, real_shape=self.real_shape, computation_dtype=self.computation_dtype)
+        new.arena = self.arena if data.data_ptr() == self.data.data_ptr() else None
+        return new
+
+    def detach(self):  # torch.nn.Parameter(p) keeps the subclass only if detach() returns it
+        return self.copy_with_data(self.data.detach())
+
+    def to(self, *args, **kwargs):  # the blob never changes dtype, only device
+        kwargs.pop("dtype", None)
+        args = tuple(a for a in args if not isinstance(a, torch.dtype))
+        return self.copy_with_data(self.data.to(*args, **kwargs))
+
+    def pin_memory(self, device=None):
+        return self.copy_with_data(torch.Tensor.pin_memory(self, device=device))
+
+    def w8(self) -> torch.Tensor:
+        n, k = self.real_shape
+        return self.data[: k * n].view(torch.int8).view(k, n)
+
+    def scale(self) -> torch.Tensor:
+        n, k = self.real_shape
+        return self.data[k * n :].view(torch.float32)
+
+    def dequantize(self, dtype=None) -> torch.Tensor:
+        return (self.w8().t().to(torch.float32) * self.scale()[:, None]).to(dtype or self.computation_dtype)
+
+
+def blob_size(n: int, k: int) -> int:
+    return k * n + 4 * n
+
+
+def quantize(weight: torch.Tensor, computation_dtype=torch.float16, out: torch.Tensor = None) -> ParameterInt8:
+    w = weight.detach().to(torch.float32)
+    s = w.abs().amax(dim=1).clamp_min_(1e-8) / 127.0
+    q = torch.round(w * (1.0 / s)[:, None]).clamp_(-127, 127).to(torch.int8).t().contiguous()
+    blob = torch.cat([q.view(-1).view(torch.uint8), s.view(torch.uint8)])
+    if out is None:
+        blob = blob.to("cpu")
+    else:
+        out.copy_(blob)
+        blob = out
+    return ParameterInt8(blob, real_shape=weight.shape, computation_dtype=computation_dtype)
+
+
+def int_mm_works(device: torch.device) -> bool:
+    try:
+        a = torch.zeros(MIN_ROWS, 8, dtype=torch.int8, device=device)
+        torch._int_mm(a, a.new_zeros(8, 8))
+        return True
+    except Exception as e:
+        logger.warning(f"int8 GEMM unavailable on {device}: {e}")
+        return False
+
+
+def quantize_model(model: torch.nn.Module) -> int:
+    name = type(model).__name__
+    if name not in INT8_MODELS:
+        logger.info(f"Not quantising {name}: its Linear layers are too small to gain from int8")
+        return 0
+
+    device = memory_management.get_torch_device()
+    if not int_mm_works(device):
+        return 0
+
+    from backend.loader_gguf import dequantize
+    from backend.operations import ForgeOperations, ForgeOperationsGGUF
+
+    supported = (ForgeOperations.Linear, ForgeOperationsGGUF.Linear)  # the Linear classes whose forward we hook
+    count, skipped, arena, at = 0, 0, None, 0
+
+    for module in model.modules():
+        if not isinstance(module, supported) or module.weight is None or module.weight.ndim != 2:
+            continue
+        n, k = module.weight.shape
+        if n % 8 or k % 8:
+            skipped += 1
+            continue
+
+        source = module.weight
+        if getattr(source, "gguf_cls", None) is not None:
+            source = dequantize(source.to(device), torch.float16)
+        else:
+            source = source.to(device=device, dtype=torch.float16)
+
+        size = blob_size(n, k)
+        if arena is None or at + size > arena.numel():
+            arena, at = torch.empty(max(size, ARENA_BYTES), dtype=torch.uint8), 0
+        weight = quantize(source, getattr(module.weight, "computation_dtype", torch.float16), out=arena[at : at + size])
+        weight.arena = arena
+        at += size
+
+        module.weight = weight
+        module.convert_weight = convert_weight  # the patcher merges a LoRA through these
+        module.set_weight = partial(set_weight, module)
+        count += 1
+
+    logger.info(f"Quantised {count} Linear layers of {name} to int8 ({skipped} skipped)")
+    return count
+
+
+def convert_weight(weight: ParameterInt8, inplace=False) -> torch.Tensor:
+    return weight.dequantize()
+
+
+def set_weight(layer, out_weight: torch.Tensor, inplace_update=False, seed=None, return_weight=False):
+    if return_weight:
+        return out_weight
+    layer.weight = quantize(out_weight, layer.weight.computation_dtype).to(out_weight.device)
+    layer.__dict__.pop("_int8_lora", None)
+
+
+def lora_entries(layer) -> list | None:
+    """(strength, adapter, offset) for every plain up/down LoRA; None if anything needs the merge instead"""
+    entries = []
+    for fn in layer.weight_function:
+        if hasattr(fn, "patches"):  # LowVramPatch
+            patches = fn.patches.get(fn.key, [])
+        elif hasattr(fn, "patch"):  # OnlineLoRAPatch
+            patches = fn.patch
+        else:
+            return None
+        for strength, v, strength_model, offset, function in patches:
+            weights = getattr(v, "weights", None)
+            if getattr(v, "name", None) != "lora" or weights is None or function is not None or strength_model != 1.0:
+                return None
+            if weights[3] is not None or weights[4] is not None or weights[5] is not None:  # mid / dora / reshape
+                return None
+            entries.append((strength, v, offset))
+    return entries
+
+
+def lora_lowrank(layer, x2: torch.Tensor, entries: list) -> list:
+    """x @ down^T for every LoRA: [tokens, rank], small enough to keep whole; up^T is applied per block"""
+    sig = tuple((id(v), float(strength)) for strength, v, _ in entries)
+    cached = layer.__dict__.get("_int8_lora")
+    if cached is None or cached[0] != sig:
+        mats = []
+        for strength, v, offset in entries:
+            up, down, alpha = v.weights[0], v.weights[1], v.weights[2]
+            scale = strength * (alpha / down.shape[0] if alpha is not None else 1.0)
+            down_t = down.flatten(start_dim=1).to(device=x2.device, dtype=x2.dtype).t().contiguous()
+            up_t = (up.flatten(start_dim=1).to(device=x2.device, dtype=torch.float32) * scale).to(x2.dtype).t().contiguous()
+            mats.append((down_t, up_t, offset))
+        layer._int8_lora = cached = (sig, mats)
+
+    low = []
+    for down_t, up_t, offset in cached[1]:
+        src = x2 if offset is None or offset[0] == 0 else x2[:, offset[1] : offset[1] + offset[2]]
+        low.append((src @ down_t, up_t, offset))
+    return low
+
+
+def int8_linear(x: torch.Tensor, weight: ParameterInt8, bias: torch.Tensor, layer, lora: list) -> torch.Tensor:
+    """
+    Row blocks: _int_mm gives int32 and the rescale needs fp32, so holding the whole output costs 8 bytes per
+    element against the 2 of the fp16 result - at hires that is over a gigabyte for one layer.
+    """
+    shape = x.shape
+    x2 = x.reshape(-1, shape[-1])
+    rows, n = x2.shape[0], weight.real_shape[0]
+    w8, s_w = weight.w8(), weight.scale()
+    low = lora_lowrank(layer, x2, lora) if lora else ()
+
+    out = torch.empty(rows, n, dtype=x.dtype, device=x.device)
+    block = max(MIN_ROWS, BLOCK_BYTES // (8 * n))
+    for i in range(0, rows, block):
+        j = min(i + block, rows)
+        xb = x2[i:j]
+        if j - i < MIN_ROWS:
+            xb = torch.nn.functional.pad(xb, (0, 0, 0, MIN_ROWS - (j - i)))
+
+        s_x = xb.abs().amax(dim=1).float().clamp_min_(1e-8) / 127.0
+        x8 = torch.round(xb.float() * (1.0 / s_x)[:, None]).clamp_(-127, 127).to(torch.int8)
+        ob = torch._int_mm(x8, w8)[: j - i] * s_x[: j - i, None]  # the int32 sum is exact, the scaling stays fp32
+        ob.mul_(s_w[None, :])
+        ob = ob.to(x.dtype)
+        if bias is not None:
+            ob += bias
+        for lo, up_t, offset in low:
+            if offset is None or offset[0] != 0:
+                ob.addmm_(lo[i:j], up_t)
+            else:  # a LoRA trained on one part of a fused weight (q / k / v of a qkv)
+                ob[:, offset[1] : offset[1] + offset[2]].addmm_(lo[i:j], up_t)
+        out[i:j] = ob
+
+    return out.reshape(*shape[:-1], n)
+
+
+def forward(layer, x: torch.Tensor) -> torch.Tensor:
+    from backend.operations import main_stream_worker, weights_manual_cast
+
+    lora = lora_entries(layer) if layer.weight_function else []
+    functions, layer.weight_function = layer.weight_function, []  # the blob goes through the cast untouched
+    try:
+        weight, bias, signal = weights_manual_cast(layer, x, skip_weight_dtype=True)
+    finally:
+        layer.weight_function = functions
+
+    with main_stream_worker(weight, bias, signal):
+        if lora is not None:
+            return int8_linear(x, weight, bias, layer, lora)
+        w = weight.dequantize(x.dtype)  # a patch the side branch cannot express: fp16 with the merge
+        for f in functions:
+            w = f(w)
+        return torch.nn.functional.linear(x, w, bias)


### PR DESCRIPTION
On a GPU without fp8 hardware the backend has no 8-bit compute path at all. torch._int_mm is one, and it reaches int8 tensor hardware that fp16 cannot use - the case for everything up to and including Ampere. Measured 2.3x to 3.1x on the DiT models, 2.7x on average.

Two commits, the second optional:

- **`--int8-linear`** - the Linear weights of a supported DiT are quantised once at load, per output channel,
  and the GEMMs run through `torch._int_mm` with per-token activation scales. A plain up/down LoRA is applied
  as a low-rank side branch instead of being merged into the weight; anything else dequantises and takes the
  usual merge.
- **`--int8-cache`** - keeps the quantised weights in `models/int8` instead of redoing the conversion at
  every load, which also avoids holding the source model and the int8 model in RAM at the same time.

Off by default, no new dependency.

## Measured

GTX 1070 8 GB, Windows, torch 2.10+cu126. 768x1024, 20 steps unless noted, second generation of a session.

| model | stock | int8 | image vs stock |
|---|---|---|---|
| **Chroma1-HD Q4_0, CFG 4** | **38.0 s/it — 14m26s** | **14.2 s/it — 4m57s** | 21.3 dB |
| Flux.1-dev Q4_0 | 25.2 s/it — 8m53s | 8.1 s/it — 2m51s | 29.5 dB |
| Flux.1-dev Q4_0 + LoRA | 21.6 s/it — 7m38s | 8.5 s/it — 2m59s | — |
| Z-Image-Turbo Q4_K_M, 8 steps | 16.3 s/it — 2m34s | 7.2 s/it — 1m07s | 21.4 dB |
| Z-Image + Hires 2x to 1536x2048 | 16m47s | 8m49s | 22.8 dB |
| SDXL RealVisXL | 2.87 s/it | 2.77, not quantised | — |
| Wan 2.1 1.3B, one frame, 8 steps | 5.35 s/it | 4.56, not quantised | identical |

SDXL's UNet and Wan's 1.3B DiT are not quantised - their GEMMs are too small to pay for the unfused quantise
and rescale passes. PSNR understates the few-step and high-CFG models: geometry shifts by a pixel or two
while pose and composition hold.

LoRA behaves as it does with the stock merge, stacking and strengths included, and unloading it restores the
base image exactly. Hires fix needs the output computed in row blocks - holding it whole costs 8 bytes per
element against the 2 of fp16, which at 1536x2048 pushed this card into driver paging: 264 s/it before the
blocking, 38 after.

**Where it helps:** Pascal, Turing and Ampere (10, 20, 30 series), which have int8 tensor cores but no fp8. From Ada (40 series) onwards
`--fast-fp8` already covers this.

## Examples:

<img width="718" height="515" alt="pr_img_flux" src="https://github.com/user-attachments/assets/abbf28b0-c486-44cc-9a38-30ccc3a8cd7b" />
<img width="718" height="515" alt="pr_img_chroma" src="https://github.com/user-attachments/assets/69208ea3-c819-4600-944e-3af1fee2b5aa" />
<img width="718" height="515" alt="pr_img_zimage" src="https://github.com/user-attachments/assets/b792a1da-d568-4829-bfb9-579bf901babe" />

